### PR TITLE
fix(mo2-mcp): graceful fallback when broker lacks profile.active / mods.meta_write (#12)

### DIFF
--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/profile-guard.d.ts
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/profile-guard.d.ts
@@ -1,4 +1,6 @@
 import type { ToolContext } from "./types.js";
+/** @internal test-only reset for the dedup'd warning state. */
+export declare function _resetStaleBrokerWarnedForTests(): void;
 /**
  * Structured error thrown when assertActiveProfile detects MO2 is alive on a
  * different profile than the requested mutation target.

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/profile-guard.js
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/profile-guard.js
@@ -1,4 +1,76 @@
+import { join } from "node:path";
 import { requireBoundContext } from "./binding.js";
+import { readMoIni } from "./mo-ini.js";
+const METHOD_NOT_FOUND_CODE = "method_not_found";
+const UNSUPPORTED_METHOD_PREFIX = "Unsupported method";
+/**
+ * Resolve the live active profile, preferring broker `profile.active` and
+ * falling back to `ModOrganizer.ini [General] selected_profile` when the
+ * deployed broker lacks the handler.
+ *
+ * BUG-23 (issue #12) fix (2026-06-25): the MCP wire layer (tools/mo2-mcp) is
+ * version-synced through the materialized plugin tree, but the Python broker
+ * lives at <MO2_Root>/plugins/mo2_agent_control.py and is per-instance
+ * deployed by install-mo2-control-plane.ps1. A stale broker — one that
+ * predates the addition of `profile.active` and `mods.meta_write` handlers —
+ * silently breaks every T3 mutating tool because assertActiveProfile bombs on
+ * `Unsupported method: profile.active` (collapsed to `internal_error` by
+ * dispatch.ts). The ini fallback uses the same decodeIniValue path that
+ * mo2_modlist already relies on, so Chinese / non-ASCII profile names work
+ * correctly. We emit a one-time stderr warning per session so the user knows
+ * a redeploy is recommended for the more accurate broker path (which reflects
+ * mid-session profile switches before MO2 flushes selected_profile to disk).
+ */
+async function resolveActiveProfile(ctx) {
+    const bound = requireBoundContext(ctx);
+    const pipeClient = bound.pipeClient;
+    if (pipeClient) {
+        try {
+            const response = await pipeClient.call("profile.active", {});
+            if (response.ok) {
+                const result = response.result;
+                if (typeof result?.name === "string" && result.name.length > 0) {
+                    return result.name;
+                }
+                // Broker returned ok but no name — treat as unavailable, fall through.
+            }
+            else if (response.error?.code !== METHOD_NOT_FOUND_CODE) {
+                // Real broker error, not a stale-broker symptom; surface it.
+                throw new Error(response.error?.message ?? "profile.active broker error");
+            }
+            else {
+                warnStaleBroker("profile.active");
+            }
+        }
+        catch (e) {
+            const message = e instanceof Error ? e.message : String(e);
+            if (!message.startsWith(UNSUPPORTED_METHOD_PREFIX))
+                throw e;
+            warnStaleBroker("profile.active");
+        }
+    }
+    // INI fallback. Works without MO2 running; matches mo2_modlist semantics.
+    try {
+        const ini = await readMoIni(join(bound.config.mo2Root, "ModOrganizer.ini"));
+        return ini.general.selectedProfile ?? null;
+    }
+    catch {
+        return null;
+    }
+}
+const STALE_BROKER_WARNED = new Set();
+function warnStaleBroker(method) {
+    if (STALE_BROKER_WARNED.has(method))
+        return;
+    STALE_BROKER_WARNED.add(method);
+    process.stderr.write(`[mo2-mcp] broker lacks '${method}' handler; falling back. ` +
+        "Consider redeploying via tools/mo2-control-plane/install-mo2-control-plane.ps1 " +
+        "and restarting MO2.\n");
+}
+/** @internal test-only reset for the dedup'd warning state. */
+export function _resetStaleBrokerWarnedForTests() {
+    STALE_BROKER_WARNED.clear();
+}
 /**
  * Structured error thrown when assertActiveProfile detects MO2 is alive on a
  * different profile than the requested mutation target.
@@ -29,21 +101,20 @@ export class CrossProfileMutationError extends Error {
     }
 }
 export async function assertActiveProfile(ctx, requestedProfile) {
-    const pipeClient = requireBoundContext(ctx).pipeClient;
-    if (!pipeClient)
+    const bound = requireBoundContext(ctx);
+    // No live pipe = MO2 offline = mutations land via offline INI rewrites. The
+    // cross-profile guard exists to stop live-MO2 mutations against a different
+    // in-memory profile; without a live pipe there is nothing to gate.
+    if (!bound.pipeClient)
         return;
-    const response = await pipeClient.call("profile.active", {});
-    if (!response.ok) {
-        throw new Error(response.error?.message ?? "profile.active broker error");
-    }
-    const result = response.result;
-    if (typeof result?.name !== "string") {
+    const active = await resolveActiveProfile(ctx);
+    if (active === null) {
         throw new Error("active_profile_unavailable: profile.active returned no profile name");
     }
-    if (result.name !== requestedProfile) {
+    if (active !== requestedProfile) {
         throw new CrossProfileMutationError({
             requested: requestedProfile,
-            active: result.name,
+            active,
         });
     }
 }

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/tools/mo2-edit-meta.d.ts
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/tools/mo2-edit-meta.d.ts
@@ -1,1 +1,2 @@
-export {};
+/** @internal test-only reset for the dedup'd warning state. */
+export declare function _resetMetaWriteStaleWarnedForTests(): void;

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/tools/mo2-edit-meta.js
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/tools/mo2-edit-meta.js
@@ -50,9 +50,20 @@ const handler = {
                 name: args.name,
                 updates,
             });
-            if (!resp.ok)
+            if (resp.ok) {
+                return resp.result;
+            }
+            // BUG-23 (issue #12) fix (2026-06-25): stale-broker deploys lack the
+            // mods.meta_write handler that exists in source. Gracefully fall
+            // through to the offline atomic INI rewrite below instead of bombing
+            // the whole apply. Real broker errors (lock contention, missing mod,
+            // etc.) still surface — only method_not_found triggers the fallback.
+            // The offline path's only semantic gap vs. broker is the
+            // modDataChanged signal MO2 picks up on its next refresh anyway.
+            if (resp.error?.code !== "method_not_found") {
                 throw new Error(resp.error?.message ?? "broker error");
-            return resp.result;
+            }
+            warnStaleMetaWriteBroker();
         }
         let text = "";
         try {
@@ -67,9 +78,26 @@ const handler = {
             }
         }
         await atomicWriteText(metaPath, text);
-        return { name: args.name, sections_updated: Object.keys(updates), source: "offline" };
+        return {
+            name: args.name,
+            sections_updated: Object.keys(updates),
+            source: pipeClient ? "offline_fallback_stale_broker" : "offline",
+        };
     },
 };
+let META_WRITE_STALE_WARNED = false;
+function warnStaleMetaWriteBroker() {
+    if (META_WRITE_STALE_WARNED)
+        return;
+    META_WRITE_STALE_WARNED = true;
+    process.stderr.write("[mo2-mcp] broker lacks 'mods.meta_write' handler; falling through to offline INI rewrite. " +
+        "Consider redeploying via tools/mo2-control-plane/install-mo2-control-plane.ps1 " +
+        "and restarting MO2.\n");
+}
+/** @internal test-only reset for the dedup'd warning state. */
+export function _resetMetaWriteStaleWarnedForTests() {
+    META_WRITE_STALE_WARNED = false;
+}
 registerTool({
     name: "mo2_edit_meta",
     tier: "T2",

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/src/profile-guard.ts
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/src/profile-guard.ts
@@ -1,9 +1,82 @@
+import { join } from "node:path";
 import type { ToolContext } from "./types.js";
-import { requireBoundContext, bindingSnapshot } from "./binding.js";
+import { requireBoundContext } from "./binding.js";
+import { readMoIni } from "./mo-ini.js";
 
 interface ActiveProfileResult {
   name?: unknown;
   path?: unknown;
+}
+
+const METHOD_NOT_FOUND_CODE = "method_not_found";
+const UNSUPPORTED_METHOD_PREFIX = "Unsupported method";
+
+/**
+ * Resolve the live active profile, preferring broker `profile.active` and
+ * falling back to `ModOrganizer.ini [General] selected_profile` when the
+ * deployed broker lacks the handler.
+ *
+ * BUG-23 (issue #12) fix (2026-06-25): the MCP wire layer (tools/mo2-mcp) is
+ * version-synced through the materialized plugin tree, but the Python broker
+ * lives at <MO2_Root>/plugins/mo2_agent_control.py and is per-instance
+ * deployed by install-mo2-control-plane.ps1. A stale broker — one that
+ * predates the addition of `profile.active` and `mods.meta_write` handlers —
+ * silently breaks every T3 mutating tool because assertActiveProfile bombs on
+ * `Unsupported method: profile.active` (collapsed to `internal_error` by
+ * dispatch.ts). The ini fallback uses the same decodeIniValue path that
+ * mo2_modlist already relies on, so Chinese / non-ASCII profile names work
+ * correctly. We emit a one-time stderr warning per session so the user knows
+ * a redeploy is recommended for the more accurate broker path (which reflects
+ * mid-session profile switches before MO2 flushes selected_profile to disk).
+ */
+async function resolveActiveProfile(ctx: ToolContext): Promise<string | null> {
+  const bound = requireBoundContext(ctx);
+  const pipeClient = bound.pipeClient;
+  if (pipeClient) {
+    try {
+      const response = await pipeClient.call("profile.active", {});
+      if (response.ok) {
+        const result = response.result as ActiveProfileResult | undefined;
+        if (typeof result?.name === "string" && result.name.length > 0) {
+          return result.name;
+        }
+        // Broker returned ok but no name — treat as unavailable, fall through.
+      } else if (response.error?.code !== METHOD_NOT_FOUND_CODE) {
+        // Real broker error, not a stale-broker symptom; surface it.
+        throw new Error(response.error?.message ?? "profile.active broker error");
+      } else {
+        warnStaleBroker("profile.active");
+      }
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      if (!message.startsWith(UNSUPPORTED_METHOD_PREFIX)) throw e;
+      warnStaleBroker("profile.active");
+    }
+  }
+  // INI fallback. Works without MO2 running; matches mo2_modlist semantics.
+  try {
+    const ini = await readMoIni(join(bound.config.mo2Root, "ModOrganizer.ini"));
+    return ini.general.selectedProfile ?? null;
+  } catch {
+    return null;
+  }
+}
+
+const STALE_BROKER_WARNED = new Set<string>();
+
+function warnStaleBroker(method: string): void {
+  if (STALE_BROKER_WARNED.has(method)) return;
+  STALE_BROKER_WARNED.add(method);
+  process.stderr.write(
+    `[mo2-mcp] broker lacks '${method}' handler; falling back. ` +
+      "Consider redeploying via tools/mo2-control-plane/install-mo2-control-plane.ps1 " +
+      "and restarting MO2.\n",
+  );
+}
+
+/** @internal test-only reset for the dedup'd warning state. */
+export function _resetStaleBrokerWarnedForTests(): void {
+  STALE_BROKER_WARNED.clear();
 }
 
 /**
@@ -42,23 +115,20 @@ export async function assertActiveProfile(
   ctx: ToolContext,
   requestedProfile: string,
 ): Promise<void> {
-  const pipeClient = requireBoundContext(ctx).pipeClient;
-  if (!pipeClient) return;
+  const bound = requireBoundContext(ctx);
+  // No live pipe = MO2 offline = mutations land via offline INI rewrites. The
+  // cross-profile guard exists to stop live-MO2 mutations against a different
+  // in-memory profile; without a live pipe there is nothing to gate.
+  if (!bound.pipeClient) return;
 
-  const response = await pipeClient.call("profile.active", {});
-  if (!response.ok) {
-    throw new Error(response.error?.message ?? "profile.active broker error");
-  }
-
-  const result = response.result as ActiveProfileResult | undefined;
-  if (typeof result?.name !== "string") {
+  const active = await resolveActiveProfile(ctx);
+  if (active === null) {
     throw new Error("active_profile_unavailable: profile.active returned no profile name");
   }
-
-  if (result.name !== requestedProfile) {
+  if (active !== requestedProfile) {
     throw new CrossProfileMutationError({
       requested: requestedProfile,
-      active: result.name,
+      active,
     });
   }
 }

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/src/tools/mo2-edit-meta.ts
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/src/tools/mo2-edit-meta.ts
@@ -11,7 +11,7 @@ import { routeToPlanApply, type PlanApplyHandler } from "../plan-apply.js";
 import { atomicWriteText } from "../atomic.js";
 import { resolveModMetaPath } from "../path-helpers.js";
 import { upsertIniValue } from "../ini-helpers.js";
-import { requireBoundContext, bindingSnapshot } from "../binding.js";
+import { requireBoundContext } from "../binding.js";
 
 // BUG-10 fix (2026-06-17): name + plan_id + lease_token gain .min(1). `updates`
 // keys/values are arbitrary INI section/value pairs and may legitimately be
@@ -55,8 +55,20 @@ const handler: PlanApplyHandler = {
         name: args.name,
         updates,
       });
-      if (!resp.ok) throw new Error(resp.error?.message ?? "broker error");
-      return resp.result as Record<string, unknown>;
+      if (resp.ok) {
+        return resp.result as Record<string, unknown>;
+      }
+      // BUG-23 (issue #12) fix (2026-06-25): stale-broker deploys lack the
+      // mods.meta_write handler that exists in source. Gracefully fall
+      // through to the offline atomic INI rewrite below instead of bombing
+      // the whole apply. Real broker errors (lock contention, missing mod,
+      // etc.) still surface — only method_not_found triggers the fallback.
+      // The offline path's only semantic gap vs. broker is the
+      // modDataChanged signal MO2 picks up on its next refresh anyway.
+      if (resp.error?.code !== "method_not_found") {
+        throw new Error(resp.error?.message ?? "broker error");
+      }
+      warnStaleMetaWriteBroker();
     }
     let text = "";
     try {
@@ -70,9 +82,30 @@ const handler: PlanApplyHandler = {
       }
     }
     await atomicWriteText(metaPath, text);
-    return { name: args.name, sections_updated: Object.keys(updates), source: "offline" };
+    return {
+      name: args.name,
+      sections_updated: Object.keys(updates),
+      source: pipeClient ? "offline_fallback_stale_broker" : "offline",
+    };
   },
 };
+
+let META_WRITE_STALE_WARNED = false;
+
+function warnStaleMetaWriteBroker(): void {
+  if (META_WRITE_STALE_WARNED) return;
+  META_WRITE_STALE_WARNED = true;
+  process.stderr.write(
+    "[mo2-mcp] broker lacks 'mods.meta_write' handler; falling through to offline INI rewrite. " +
+      "Consider redeploying via tools/mo2-control-plane/install-mo2-control-plane.ps1 " +
+      "and restarting MO2.\n",
+  );
+}
+
+/** @internal test-only reset for the dedup'd warning state. */
+export function _resetMetaWriteStaleWarnedForTests(): void {
+  META_WRITE_STALE_WARNED = false;
+}
 
 registerTool({
   name: "mo2_edit_meta",

--- a/tools/mo2-mcp/src/profile-guard.ts
+++ b/tools/mo2-mcp/src/profile-guard.ts
@@ -1,9 +1,82 @@
+import { join } from "node:path";
 import type { ToolContext } from "./types.js";
-import { requireBoundContext, bindingSnapshot } from "./binding.js";
+import { requireBoundContext } from "./binding.js";
+import { readMoIni } from "./mo-ini.js";
 
 interface ActiveProfileResult {
   name?: unknown;
   path?: unknown;
+}
+
+const METHOD_NOT_FOUND_CODE = "method_not_found";
+const UNSUPPORTED_METHOD_PREFIX = "Unsupported method";
+
+/**
+ * Resolve the live active profile, preferring broker `profile.active` and
+ * falling back to `ModOrganizer.ini [General] selected_profile` when the
+ * deployed broker lacks the handler.
+ *
+ * BUG-23 (issue #12) fix (2026-06-25): the MCP wire layer (tools/mo2-mcp) is
+ * version-synced through the materialized plugin tree, but the Python broker
+ * lives at <MO2_Root>/plugins/mo2_agent_control.py and is per-instance
+ * deployed by install-mo2-control-plane.ps1. A stale broker — one that
+ * predates the addition of `profile.active` and `mods.meta_write` handlers —
+ * silently breaks every T3 mutating tool because assertActiveProfile bombs on
+ * `Unsupported method: profile.active` (collapsed to `internal_error` by
+ * dispatch.ts). The ini fallback uses the same decodeIniValue path that
+ * mo2_modlist already relies on, so Chinese / non-ASCII profile names work
+ * correctly. We emit a one-time stderr warning per session so the user knows
+ * a redeploy is recommended for the more accurate broker path (which reflects
+ * mid-session profile switches before MO2 flushes selected_profile to disk).
+ */
+async function resolveActiveProfile(ctx: ToolContext): Promise<string | null> {
+  const bound = requireBoundContext(ctx);
+  const pipeClient = bound.pipeClient;
+  if (pipeClient) {
+    try {
+      const response = await pipeClient.call("profile.active", {});
+      if (response.ok) {
+        const result = response.result as ActiveProfileResult | undefined;
+        if (typeof result?.name === "string" && result.name.length > 0) {
+          return result.name;
+        }
+        // Broker returned ok but no name — treat as unavailable, fall through.
+      } else if (response.error?.code !== METHOD_NOT_FOUND_CODE) {
+        // Real broker error, not a stale-broker symptom; surface it.
+        throw new Error(response.error?.message ?? "profile.active broker error");
+      } else {
+        warnStaleBroker("profile.active");
+      }
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      if (!message.startsWith(UNSUPPORTED_METHOD_PREFIX)) throw e;
+      warnStaleBroker("profile.active");
+    }
+  }
+  // INI fallback. Works without MO2 running; matches mo2_modlist semantics.
+  try {
+    const ini = await readMoIni(join(bound.config.mo2Root, "ModOrganizer.ini"));
+    return ini.general.selectedProfile ?? null;
+  } catch {
+    return null;
+  }
+}
+
+const STALE_BROKER_WARNED = new Set<string>();
+
+function warnStaleBroker(method: string): void {
+  if (STALE_BROKER_WARNED.has(method)) return;
+  STALE_BROKER_WARNED.add(method);
+  process.stderr.write(
+    `[mo2-mcp] broker lacks '${method}' handler; falling back. ` +
+      "Consider redeploying via tools/mo2-control-plane/install-mo2-control-plane.ps1 " +
+      "and restarting MO2.\n",
+  );
+}
+
+/** @internal test-only reset for the dedup'd warning state. */
+export function _resetStaleBrokerWarnedForTests(): void {
+  STALE_BROKER_WARNED.clear();
 }
 
 /**
@@ -42,23 +115,20 @@ export async function assertActiveProfile(
   ctx: ToolContext,
   requestedProfile: string,
 ): Promise<void> {
-  const pipeClient = requireBoundContext(ctx).pipeClient;
-  if (!pipeClient) return;
+  const bound = requireBoundContext(ctx);
+  // No live pipe = MO2 offline = mutations land via offline INI rewrites. The
+  // cross-profile guard exists to stop live-MO2 mutations against a different
+  // in-memory profile; without a live pipe there is nothing to gate.
+  if (!bound.pipeClient) return;
 
-  const response = await pipeClient.call("profile.active", {});
-  if (!response.ok) {
-    throw new Error(response.error?.message ?? "profile.active broker error");
-  }
-
-  const result = response.result as ActiveProfileResult | undefined;
-  if (typeof result?.name !== "string") {
+  const active = await resolveActiveProfile(ctx);
+  if (active === null) {
     throw new Error("active_profile_unavailable: profile.active returned no profile name");
   }
-
-  if (result.name !== requestedProfile) {
+  if (active !== requestedProfile) {
     throw new CrossProfileMutationError({
       requested: requestedProfile,
-      active: result.name,
+      active,
     });
   }
 }

--- a/tools/mo2-mcp/src/tools/mo2-edit-meta.ts
+++ b/tools/mo2-mcp/src/tools/mo2-edit-meta.ts
@@ -11,7 +11,7 @@ import { routeToPlanApply, type PlanApplyHandler } from "../plan-apply.js";
 import { atomicWriteText } from "../atomic.js";
 import { resolveModMetaPath } from "../path-helpers.js";
 import { upsertIniValue } from "../ini-helpers.js";
-import { requireBoundContext, bindingSnapshot } from "../binding.js";
+import { requireBoundContext } from "../binding.js";
 
 // BUG-10 fix (2026-06-17): name + plan_id + lease_token gain .min(1). `updates`
 // keys/values are arbitrary INI section/value pairs and may legitimately be
@@ -55,8 +55,20 @@ const handler: PlanApplyHandler = {
         name: args.name,
         updates,
       });
-      if (!resp.ok) throw new Error(resp.error?.message ?? "broker error");
-      return resp.result as Record<string, unknown>;
+      if (resp.ok) {
+        return resp.result as Record<string, unknown>;
+      }
+      // BUG-23 (issue #12) fix (2026-06-25): stale-broker deploys lack the
+      // mods.meta_write handler that exists in source. Gracefully fall
+      // through to the offline atomic INI rewrite below instead of bombing
+      // the whole apply. Real broker errors (lock contention, missing mod,
+      // etc.) still surface — only method_not_found triggers the fallback.
+      // The offline path's only semantic gap vs. broker is the
+      // modDataChanged signal MO2 picks up on its next refresh anyway.
+      if (resp.error?.code !== "method_not_found") {
+        throw new Error(resp.error?.message ?? "broker error");
+      }
+      warnStaleMetaWriteBroker();
     }
     let text = "";
     try {
@@ -70,9 +82,30 @@ const handler: PlanApplyHandler = {
       }
     }
     await atomicWriteText(metaPath, text);
-    return { name: args.name, sections_updated: Object.keys(updates), source: "offline" };
+    return {
+      name: args.name,
+      sections_updated: Object.keys(updates),
+      source: pipeClient ? "offline_fallback_stale_broker" : "offline",
+    };
   },
 };
+
+let META_WRITE_STALE_WARNED = false;
+
+function warnStaleMetaWriteBroker(): void {
+  if (META_WRITE_STALE_WARNED) return;
+  META_WRITE_STALE_WARNED = true;
+  process.stderr.write(
+    "[mo2-mcp] broker lacks 'mods.meta_write' handler; falling through to offline INI rewrite. " +
+      "Consider redeploying via tools/mo2-control-plane/install-mo2-control-plane.ps1 " +
+      "and restarting MO2.\n",
+  );
+}
+
+/** @internal test-only reset for the dedup'd warning state. */
+export function _resetMetaWriteStaleWarnedForTests(): void {
+  META_WRITE_STALE_WARNED = false;
+}
 
 registerTool({
   name: "mo2_edit_meta",

--- a/tools/mo2-mcp/tests/profile-guard.test.ts
+++ b/tools/mo2-mcp/tests/profile-guard.test.ts
@@ -1,6 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import { z } from "zod";
-import { assertActiveProfile, CrossProfileMutationError } from "../src/profile-guard.js";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  assertActiveProfile,
+  CrossProfileMutationError,
+  _resetStaleBrokerWarnedForTests,
+} from "../src/profile-guard.js";
 import { dispatchToolCall } from "../src/dispatch.js";
 import { AuditLogger } from "../src/audit.js";
 import { PlanCache } from "../src/plan-apply.js";
@@ -8,6 +15,63 @@ import { SnapshotManager } from "../src/snapshot.js";
 import { _clearToolsForTests, registerTool } from "../src/tool-registry.js";
 import type { ToolContext } from "../src/types.js";
 import type { Config } from "../src/config.js";
+
+/**
+ * Build a context where the pipe is alive but reports `method_not_found` for
+ * `profile.active` (the stale-broker scenario from issue #12). The bound
+ * mo2Root points at a temp dir containing a real ModOrganizer.ini whose
+ * [General] selected_profile is set to `iniProfile`. This mirrors how the
+ * fallback should resolve when the deployed broker is older than the source
+ * tree's profile.active handler.
+ */
+async function ctxWithStaleBrokerAndIni(opts: {
+  iniProfile?: string;
+  iniProfileByteArray?: boolean;
+  /** When set, returns this error code/message instead of method_not_found. */
+  brokerError?: { code: string; message: string };
+}): Promise<{ ctx: ToolContext; root: string }> {
+  const root = await mkdtemp(join(tmpdir(), "mo2-staleb-"));
+  if (opts.iniProfile) {
+    const profileLine = opts.iniProfileByteArray
+      ? `selected_profile=@ByteArray(${opts.iniProfile})`
+      : `selected_profile=${opts.iniProfile}`;
+    await writeFile(
+      join(root, "ModOrganizer.ini"),
+      `[General]\ngame=fallout4\ngameName=Fallout4\n${profileLine}\n[Settings]\nbase_directory=${root}\n`,
+      "utf8",
+    );
+  } else {
+    await writeFile(
+      join(root, "ModOrganizer.ini"),
+      `[General]\ngame=fallout4\ngameName=Fallout4\n[Settings]\nbase_directory=${root}\n`,
+      "utf8",
+    );
+  }
+  const ctx = {
+    config: {
+      mo2Root: root,
+      allowedProfiles: ["Default"],
+      permissionCeiling: "metadata-editable",
+      deny: [],
+      snapshotRoot: join(root, ".mo2-mcp", "snapshots"),
+      auditRoot: join(root, ".mo2-mcp", "audit"),
+    },
+    pipeClient: {
+      call: async () => ({
+        ok: false,
+        result: null,
+        error: opts.brokerError ?? {
+          code: "method_not_found",
+          message: "Unsupported method: profile.active",
+        },
+      }),
+      close: () => {},
+      discoverAndConnect: async () => {},
+      isConnected: () => true,
+    },
+  } as unknown as ToolContext;
+  return { ctx, root };
+}
 
 function ctxWithActiveProfile(activeProfile?: string): ToolContext {
   // Legacy compat shape: ToolContext at runtime carries `binding`, but
@@ -48,6 +112,72 @@ describe("assertActiveProfile", () => {
   // CrossProfileMutationError so dispatch.ts can surface a structured envelope
   // with code='cross_profile_live_mutation_blocked' instead of collapsing it
   // to internal_error.
+  // BUG-23 (issue #12) fix (2026-06-25): when the deployed Python broker
+  // predates the addition of the `profile.active` handler, the broker returns
+  // `{ok: false, error: {code: "method_not_found", ...}}`. assertActiveProfile
+  // now treats that specific error as "fall back to ModOrganizer.ini
+  // [General] selected_profile" instead of bombing the whole T3 mutator
+  // chain. The ini fallback uses the same decodeIniValue path as
+  // mo2_modlist, so non-ASCII profile names round-trip correctly.
+  describe("BUG-23: stale-broker fallback for profile.active", () => {
+    const tempDirs: string[] = [];
+    beforeEach(() => {
+      _resetStaleBrokerWarnedForTests();
+    });
+    afterAll(async () => {
+      for (const dir of tempDirs) {
+        await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+      }
+    });
+
+    it("falls back to ini selected_profile when broker returns method_not_found (match)", async () => {
+      const { ctx, root } = await ctxWithStaleBrokerAndIni({ iniProfile: "Default" });
+      tempDirs.push(root);
+      await expect(assertActiveProfile(ctx, "Default")).resolves.toBeUndefined();
+    });
+
+    it("falls back to ini selected_profile when broker returns method_not_found (mismatch -> CrossProfileMutationError)", async () => {
+      const { ctx, root } = await ctxWithStaleBrokerAndIni({ iniProfile: "Default" });
+      tempDirs.push(root);
+      try {
+        await assertActiveProfile(ctx, "OtherProfile");
+        throw new Error("expected CrossProfileMutationError");
+      } catch (e) {
+        expect(e).toBeInstanceOf(CrossProfileMutationError);
+        const err = e as CrossProfileMutationError;
+        expect(err.details).toEqual({
+          requested: "OtherProfile",
+          active: "Default",
+          hint: "Use mo2_switch_profile to switch first, or stop MO2 to use offline mutation.",
+        });
+      }
+    });
+
+    it("decodes @ByteArray(\\xHH) in ini fallback so Chinese profile names work end-to-end", async () => {
+      // Issue #12 Bug 1 + Bug 2 intersection: the user's real install has
+      // selected_profile=@ByteArray(BB84\xe8\x87\xaa\xe7\x94\xa8\x32) which
+      // decodes to "BB84自用2". assertActiveProfile must use the decoded form
+      // so cross-profile detection works against requests passing the same
+      // decoded form (which is what every other tool — Mo2Mo2Modlist,
+      // Mo2Mo2ToggleMod — uses).
+      const { ctx, root } = await ctxWithStaleBrokerAndIni({
+        iniProfile: "BB84\\xe8\\x87\\xaa\\xe7\\x94\\xa8\\x32",
+        iniProfileByteArray: true,
+      });
+      tempDirs.push(root);
+      await expect(assertActiveProfile(ctx, "BB84自用2")).resolves.toBeUndefined();
+    });
+
+    it("still surfaces non-method_not_found broker errors (does NOT swallow real failures)", async () => {
+      const { ctx, root } = await ctxWithStaleBrokerAndIni({
+        iniProfile: "Default",
+        brokerError: { code: "internal_error", message: "broker exploded" },
+      });
+      tempDirs.push(root);
+      await expect(assertActiveProfile(ctx, "Default")).rejects.toThrow(/broker exploded/);
+    });
+  });
+
   it("BUG-21: throws CrossProfileMutationError (not plain Error) on mismatch", async () => {
     try {
       await assertActiveProfile(ctxWithActiveProfile("Default"), "BB84自用");

--- a/tools/mo2-mcp/tests/tools/mo2-edit-meta.test.ts
+++ b/tools/mo2-mcp/tests/tools/mo2-edit-meta.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { mkdtemp, mkdir, writeFile, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -8,7 +8,24 @@ import { SnapshotManager } from "../../src/snapshot.js";
 import { AuditLogger } from "../../src/audit.js";
 import type { ToolContext } from "../../src/types.js";
 
-async function _fixture(): Promise<{ root: string; ctx: ToolContext }> {
+// Loaded inside beforeAll after _clearToolsForTests + the dynamic
+// mo2-edit-meta import; static imports here would evaluate the module first
+// and the subsequent dynamic import would return a cached, already-registered
+// module that the registry clear has just wiped.
+let _resetMetaWriteStaleWarnedForTests: () => void = () => {};
+
+interface FixtureCtx extends ToolContext {
+  pipeClient?: {
+    call: (method: string, payload: Record<string, unknown>) => Promise<{ ok: boolean; result: unknown; error: { code: string; message: string } | null }>;
+    close: () => void;
+    discoverAndConnect: () => Promise<void>;
+    isConnected: () => boolean;
+  };
+}
+
+async function _fixture(opts: {
+  pipeBehavior?: "absent" | "method_not_found" | "ok" | "real_error";
+} = {}): Promise<{ root: string; ctx: FixtureCtx }> {
   const root = await mkdtemp(join(tmpdir(), "mo2-em-"));
   await writeFile(
     join(root, "ModOrganizer.ini"),
@@ -17,7 +34,7 @@ async function _fixture(): Promise<{ root: string; ctx: ToolContext }> {
   );
   await mkdir(join(root, "mods", "ModA"), { recursive: true });
   await writeFile(join(root, "mods", "ModA", "meta.ini"), "[General]\nversion=1.0\n", "utf8");
-  const ctx: ToolContext = {
+  const ctx: FixtureCtx = {
     config: {
       mo2Root: root,
       permissionCeiling: "metadata-editable",
@@ -30,14 +47,43 @@ async function _fixture(): Promise<{ root: string; ctx: ToolContext }> {
     plans: new PlanCache(),
     snapshots: new SnapshotManager(join(root, ".mo2-mcp", "snapshots"), "test"),
     audit: new AuditLogger(join(root, ".mo2-mcp", "audit"), "test"),
-  };
+  } as FixtureCtx;
+  if (opts.pipeBehavior && opts.pipeBehavior !== "absent") {
+    ctx.pipeClient = {
+      call: async () => {
+        if (opts.pipeBehavior === "ok") {
+          return { ok: true, result: { source: "broker", name: "ModA" }, error: null };
+        }
+        if (opts.pipeBehavior === "real_error") {
+          return {
+            ok: false,
+            result: null,
+            error: { code: "mod_not_found", message: "ModA: not in modList" },
+          };
+        }
+        return {
+          ok: false,
+          result: null,
+          error: { code: "method_not_found", message: "Unsupported method: mods.meta_write" },
+        };
+      },
+      close: () => {},
+      discoverAndConnect: async () => {},
+      isConnected: () => true,
+    };
+  }
   return { root, ctx };
 }
 
 describe("mo2_edit_meta", () => {
   beforeAll(async () => {
     _clearToolsForTests();
-    await import("../../src/tools/mo2-edit-meta.js");
+    const mod = await import("../../src/tools/mo2-edit-meta.js");
+    _resetMetaWriteStaleWarnedForTests = mod._resetMetaWriteStaleWarnedForTests;
+  });
+
+  beforeEach(() => {
+    _resetMetaWriteStaleWarnedForTests();
   });
 
   it("registers as T2", () => {
@@ -66,5 +112,87 @@ describe("mo2_edit_meta", () => {
     const meta = await readFile(join(root, "mods", "ModA", "meta.ini"), "utf8");
     expect(meta).toContain("version=2.0");
     expect(meta).toContain("nexusID=42");
+  });
+
+  // BUG-23 (issue #12) fix (2026-06-25): stale-broker installs (the deployed
+  // mo2_agent_control.py predates the source tree's mods.meta_write handler)
+  // would have apply() bomb with `Unsupported method: mods.meta_write`. The
+  // fallback path makes apply() degrade to the offline atomic INI rewrite
+  // instead of failing, preserving the clean-mutation discipline KB record
+  // install-planning.mod-mutation-cleanliness-discipline.v1 even when the
+  // broker is the laggard. Real broker errors (mod_not_found, lock
+  // contention, etc.) still surface — only method_not_found falls through.
+  describe("BUG-23: stale-broker fallback for mods.meta_write", () => {
+    it("falls through to offline INI rewrite when broker returns method_not_found", async () => {
+      const { root, ctx } = await _fixture({ pipeBehavior: "method_not_found" });
+      const tool = getTool("mo2_edit_meta")!;
+      const plan = (await tool.handler(
+        {
+          mode: "plan",
+          name: "ModA",
+          updates: { General: { comments: "[ARCHIVED 2026-06-25] superseded by ModB" } },
+        },
+        ctx,
+      )) as { ok: boolean; result: { planId: string; lease_token: string } };
+      expect(plan.ok).toBe(true);
+
+      const apply = (await tool.handler(
+        { mode: "apply", plan_id: plan.result.planId, lease_token: plan.result.lease_token },
+        ctx,
+      )) as { ok: boolean; result: { source: string } };
+      expect(apply.ok).toBe(true);
+      expect(apply.result.source).toBe("offline_fallback_stale_broker");
+
+      const meta = await readFile(join(root, "mods", "ModA", "meta.ini"), "utf8");
+      expect(meta).toContain("comments=[ARCHIVED 2026-06-25] superseded by ModB");
+      expect(meta).toContain("version=1.0"); // existing key preserved
+    });
+
+    it("surfaces non-method_not_found broker errors (does NOT swallow real failures)", async () => {
+      const { ctx } = await _fixture({ pipeBehavior: "real_error" });
+      const tool = getTool("mo2_edit_meta")!;
+      const plan = (await tool.handler(
+        {
+          mode: "plan",
+          name: "ModA",
+          updates: { General: { comments: "test" } },
+        },
+        ctx,
+      )) as { ok: boolean; result: { planId: string; lease_token: string } };
+      expect(plan.ok).toBe(true);
+
+      // applyMutation throws on non-method_not_found broker errors; routeToPlanApply
+      // does NOT catch (per plan-apply.ts:281 — wrapping happens at the
+      // dispatch.ts level, not here). The throw propagating means callers like
+      // dispatch.ts see the real failure code instead of a silent "ok: true,
+      // source: offline_fallback_stale_broker" answer that would be wrong.
+      await expect(
+        tool.handler(
+          { mode: "apply", plan_id: plan.result.planId, lease_token: plan.result.lease_token },
+          ctx,
+        ),
+      ).rejects.toThrow(/ModA: not in modList/);
+    });
+
+    it("uses broker result when broker handles the call (source != offline_fallback_stale_broker)", async () => {
+      const { ctx } = await _fixture({ pipeBehavior: "ok" });
+      const tool = getTool("mo2_edit_meta")!;
+      const plan = (await tool.handler(
+        {
+          mode: "plan",
+          name: "ModA",
+          updates: { General: { comments: "test" } },
+        },
+        ctx,
+      )) as { ok: boolean; result: { planId: string; lease_token: string } };
+      expect(plan.ok).toBe(true);
+
+      const apply = (await tool.handler(
+        { mode: "apply", plan_id: plan.result.planId, lease_token: plan.result.lease_token },
+        ctx,
+      )) as { ok: boolean; result: { source: string } };
+      expect(apply.ok).toBe(true);
+      expect(apply.result.source).toBe("broker");
+    });
   });
 });

--- a/tools/mo2-mcp/tests/tools/mo2-status.profile-resolution.test.ts
+++ b/tools/mo2-mcp/tests/tools/mo2-status.profile-resolution.test.ts
@@ -131,4 +131,31 @@ describe("mo2_status profile resolution", () => {
     expect(response.ok).toBe(false);
     expect(response.error?.code).toBe("no_profile_available");
   });
+
+  // BUG-23 (issue #12) Bug 1 regression: real Starfield install with Chinese
+  // profile name "BB84自用2" stored as
+  //   selected_profile=@ByteArray(BB84\xe8\x87\xaa\xe7\x94\xa8\x32)
+  // Earlier deploys (pre 2026-06-24 decodeIniValue \xHH upgrade) returned the
+  // literal escaped form, causing readProfile to ENOENT on the wrong path. The
+  // decoder upgrade fixed it; this test locks in the end-to-end Status path
+  // against the exact byte sequence so the bug class cannot regress silently.
+  it("BUG-23 Bug 1: Status resolves Chinese profile name encoded as @ByteArray(\\xHH)", async () => {
+    const { ctx } = await setupRoot({
+      profiles: ["BB84自用2"],
+      // The escaped form @ByteArray(BB84\xe8\x87\xaa\xe7\x94\xa8\x32)
+      // decodes via decodeIniValue to "BB84自用2".
+      selectedProfile: "BB84\\xe8\\x87\\xaa\\xe7\\x94\\xa8\\x32",
+      allowedProfiles: ["Default"],
+    });
+
+    const response = await status({}, ctx);
+
+    expect(response.ok).toBe(true);
+    expect(response.result?.profile).toBe("BB84自用2");
+    expect(response.result?.counts?.mods_total).toBe(2);
+    // Critical: the error message in issue #12 contained literal `\xHH`. This
+    // assertion proves the resolved profileName is the *decoded* form, not
+    // the escaped wire form.
+    expect(response.result?.profile).not.toMatch(/\\x[0-9a-fA-F]{2}/);
+  });
 });


### PR DESCRIPTION
Closes #12.

## Summary

Three sidecar containment breaches from the BB84 Starfield audit-closeout session (2026-06-25). Root-cause for all three: the deployed Python broker (`<MO2_Root>/plugins/mo2_agent_control.py`) was stale relative to source. The TS wire layer is version-synced via vendor-clone `git pull`; the broker is NOT auto-refreshed by a pull and must be redeployed per-MO2-instance via `install-mo2-control-plane.ps1`.

| Bug | Status | Fix |
|---|---|---|
| 1: `Mo2Mo2Status_tool` ENOENT on Chinese profile names | **Already fixed** 2026-06-24 | Locked in by new regression test (`BUG-23 Bug 1` in `mo2-status.profile-resolution.test.ts`); `decodeIniValue` `\xHH` upgrade was the actual fix |
| 2: `profile.active` `Unsupported method` (blocks all T3 mutators) | **Fixed this PR** | `profile-guard.ts` `resolveActiveProfile()` falls back to `ModOrganizer.ini [General] selected_profile` when broker returns `method_not_found` |
| 3: `mods.meta_write` `Unsupported method` (blocks all meta.ini writes) | **Fixed this PR** | `mo2-edit-meta.ts` `applyMutation()` falls through to the existing offline atomic INI rewrite path when broker returns `method_not_found` |

## Design rationale

Both Bug 2 and Bug 3 happen when the source tree adds a new broker handler but the deployed broker on a user's MO2 instance predates it. Three options:

1. **Force users to redeploy** — fails closed but breaks every existing v1.x install at upgrade time.
2. **Add the handlers to broker source** — already done (source HAS them at `mo2_agent_control.py:2740` for `profile.active`, `:2712` for `mods.meta_write`). Doesn't help users whose broker is stale.
3. **Make the TS layer resilient** — detect `error.code === "method_not_found"`, fall back to the offline / INI / native-TS code path, emit one-time stderr warning recommending redeploy. **Chosen.**

Real broker errors (`mod_not_found`, lock contention, etc.) still surface — only `method_not_found` triggers the fallback. The offline path's only semantic gap vs. broker for `mods.meta_write` is the `modDataChanged` Qt signal, which MO2 picks up on its next refresh anyway.

## Tests

- `tests/profile-guard.test.ts` `describe("BUG-23: stale-broker fallback for profile.active")` — 4 cases covering match / mismatch / Chinese-profile via ini fallback / real-error pass-through
- `tests/tools/mo2-edit-meta.test.ts` `describe("BUG-23: stale-broker fallback for mods.meta_write")` — 3 cases covering fallback success / real-error pass-through / broker-handled path
- `tests/tools/mo2-status.profile-resolution.test.ts` `BUG-23 Bug 1` — locks in Chinese profile name round-trip via `@ByteArray(BB84\xe8\x87\xaa\xe7\x94\xa8\x32)`

Full mo2-mcp suite: **512 pass / 0 fail / 2 skipped** (live acceptance excluded; requires real MO2).

## Migration notes

Existing users will see a one-time stderr warning per stale handler:

  `[mo2-mcp] broker lacks 'profile.active' handler; falling back. Consider redeploying via tools/mo2-control-plane/install-mo2-control-plane.ps1 and restarting MO2.`

Mutations still work; fallback is transparent. Redeployment is recommended (not required) for the more accurate broker path that reflects mid-session profile switches before MO2 flushes `selected_profile` to disk.

## Commits

1. `fix(mo2-mcp): graceful fallback when broker lacks profile.active / mods.meta_write (issue #12)` — source TS + tests
2. `chore(plugin-pack): rematerialize mo2-mcp after issue #12 stale-broker fallback` — materialized mirror under `plugins/bgs-modding-superpowers/tools/mo2-mcp/`

## Related rules

- `.opencode/memory/45-mo2-mcp-internals.md` rule 21 (new): TS handlers MUST treat `method_not_found` as stale-broker symptom, not fatal error.
- `.opencode/memory/45-mo2-mcp-internals.md` rule 9 (existing): broker hash-audit at end-of-batch closeout. Combined with rule 21, stale brokers degrade gracefully AND are detected.