### PR TITLE
fix(mo2-mcp): BUG-14 install lane (Data/-flatten + plugins.txt + .rar + apply-time lease) + stale pipe + above_separator priority space (issue #14)

### DIFF
--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp-sidecar/src/mo2_mcp_sidecar/archive.py
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp-sidecar/src/mo2_mcp_sidecar/archive.py
@@ -2,10 +2,19 @@
 
 Used by mo2_install's plan step to stage archive contents into
 <MO2_Root>/.mo2-mcp/staging/<install_id>/ before computing conflict preview.
+
+BUG-14 BUG-C fix (issue #14): py7zr's ``SevenZipFile`` only understands the
+7z container format and raises ``Bad7zFile: not a 7z file`` on .rar input.
+The .rar branch shells out to ``7z.exe`` (the 7-Zip CLI), which handles
+RAR natively. Nexus carries a long tail of .rar uploads (older mods, e.g.
+Starfield Extended - Craftable Quality v4.1 #5721 ships as .rar) and the
+prior code path made ``mo2_install`` unusable for them.
 """
 from __future__ import annotations
 
 import os
+import shutil
+import subprocess
 import zipfile
 from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
 from typing import Any
@@ -17,6 +26,115 @@ try:
     _PY7ZR_AVAILABLE = True
 except ImportError:
     _PY7ZR_AVAILABLE = False
+
+
+# Well-known Windows 7-Zip install paths used as a fallback when neither
+# BGS_SEVENZIP_PATH nor a PATH lookup turns up the binary.
+_WIN_7Z_FALLBACK_PATHS = (
+    r"C:\Program Files\7-Zip\7z.exe",
+    r"C:\Program Files (x86)\7-Zip\7z.exe",
+)
+
+
+def _find_7z_exe() -> str | None:
+    """Locate a usable 7-Zip CLI for shell-out extraction.
+
+    Precedence:
+      1. ``$BGS_SEVENZIP_PATH`` (explicit override; agent installs / CI)
+      2. ``shutil.which("7z")`` / ``shutil.which("7z.exe")`` (PATH lookup)
+      3. Well-known Windows install paths
+
+    Returns the resolved binary path or ``None`` if 7-Zip is not findable.
+    Callers raise an actionable error pointing at the install URL.
+    """
+    env_path = os.environ.get("BGS_SEVENZIP_PATH")
+    if env_path and Path(env_path).is_file():
+        return env_path
+    for name in ("7z", "7z.exe"):
+        which = shutil.which(name)
+        if which:
+            return which
+    for candidate in _WIN_7Z_FALLBACK_PATHS:
+        if Path(candidate).is_file():
+            return candidate
+    return None
+
+
+def _list_via_7z_exe(seven_z: str, archive_path: Path) -> list[str]:
+    """Enumerate archive members via ``7z l -slt`` so they can be pre-validated.
+
+    Defense-in-depth: even though 7-Zip itself sanitizes against absolute
+    paths and ``..`` traversal in modern versions, we still pre-list and
+    run each member through :func:`_validate_safe_member` so the contract
+    matches the .zip / .7z branches above.
+    """
+    result = subprocess.run(
+        [seven_z, "l", "-slt", str(archive_path)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip() or "(no stderr)"
+        raise RuntimeError(f"7z_list_failed: exit {result.returncode}: {stderr}")
+    members: list[str] = []
+    for line in result.stdout.splitlines():
+        if line.startswith("Path = "):
+            members.append(line[len("Path = "):])
+    # First "Path = " in -slt is the archive itself; skip.
+    return members[1:] if members else []
+
+
+def _extract_via_7z_exe(archive_path: Path, dest: Path) -> list[str]:
+    """Extract any archive 7-Zip understands (used for .rar here).
+
+    Validates each member name via :func:`_validate_safe_member` before
+    invoking the CLI. After extraction walks ``dest`` to enumerate the
+    actually-extracted files (7-Zip emits no JSON listing on stdout, so
+    a directory walk is the most portable enumeration path and keeps
+    behavior parallel to the .zip / .7z branches).
+    """
+    seven_z = _find_7z_exe()
+    if seven_z is None:
+        raise RuntimeError(
+            "7z_exe_not_found: set BGS_SEVENZIP_PATH or install 7-Zip from "
+            "https://www.7-zip.org/ to enable .rar extraction"
+        )
+
+    members = _list_via_7z_exe(seven_z, archive_path)
+    for member in members:
+        if member:
+            _validate_safe_member(member, dest)
+
+    try:
+        result = subprocess.run(
+            [
+                seven_z, "x",
+                str(archive_path),
+                f"-o{dest}",
+                "-y",
+                "-bso0",
+                "-bsp0",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("7z_exe_timeout: archive extraction exceeded 300s") from exc
+
+    if result.returncode != 0:
+        # 7z exit codes: 0=ok, 1=warning, 2=fatal, 7=cmdline, 8=memory, 255=user abort
+        stderr = (result.stderr or "").strip() or "(no stderr)"
+        raise RuntimeError(f"7z_exe_failed: exit {result.returncode}: {stderr}")
+
+    extracted: list[str] = []
+    for path in dest.rglob("*"):
+        if path.is_file():
+            extracted.append(path.relative_to(dest).as_posix())
+    return extracted
 
 
 def _is_absolute_member(member_name: str) -> bool:
@@ -110,14 +228,21 @@ def archive_extract_all(params: dict[str, Any]) -> dict[str, Any]:
                 _validate_safe_member(name, dest)
             zf.extractall(dest)
         fmt = "zip"
-    elif suffix in (".7z", ".rar"):
+    elif suffix == ".7z":
         if not _PY7ZR_AVAILABLE:
             raise RuntimeError("py7zr_not_available")
         with py7zr.SevenZipFile(archive_path) as z:
             extracted = _safe_7z_targets(list(z.list()), dest)
             if extracted:
                 z.extract(path=str(dest), targets=extracted)
-        fmt = "7z" if suffix == ".7z" else "rar"
+        fmt = "7z"
+    elif suffix == ".rar":
+        # BUG-14 BUG-C (issue #14): py7zr does NOT support RAR; routing it
+        # through SevenZipFile produced ``Bad7zFile: not a 7z file`` and
+        # made every .rar Nexus archive uninstallable via mo2_install.
+        # Shell out to 7z.exe which understands the format natively.
+        extracted = _extract_via_7z_exe(archive_path, dest)
+        fmt = "rar"
     else:
         raise RuntimeError(f"unsupported_archive_format: {suffix}")
 

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp-sidecar/tests/test_archive.py
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp-sidecar/tests/test_archive.py
@@ -83,3 +83,106 @@ def test_extract_all_7z_format(tmp_path):
 
     assert result["format"] == "7z"
     assert (dest / "inside.txt").read_text() == "inside-7z"
+
+
+# BUG-14 BUG-C (issue #14): .rar must NOT route through py7zr (Bad7zFile
+# error) and must succeed when 7z.exe is available on PATH / fallback paths
+# / via BGS_SEVENZIP_PATH override.
+class TestRarSupport:
+    def test_find_7z_exe_honors_env_override(self, tmp_path, monkeypatch):
+        fake = tmp_path / "fake-7z.exe"
+        fake.write_text("not really a binary")  # only needs to exist
+        monkeypatch.setenv("BGS_SEVENZIP_PATH", str(fake))
+        assert archive._find_7z_exe() == str(fake)
+
+    def test_find_7z_exe_ignores_nonexistent_override(self, monkeypatch):
+        monkeypatch.setenv("BGS_SEVENZIP_PATH", "/path/that/does/not/exist/7z.exe")
+        # Should fall through to PATH lookup / fallback paths; we don't
+        # assert a specific result here because it depends on the host's
+        # 7-Zip install. We just assert it doesn't raise.
+        result = archive._find_7z_exe()
+        assert result is None or Path(result).is_file()
+
+    def test_extract_rar_raises_clear_error_when_7z_exe_missing(self, tmp_path, monkeypatch):
+        # Force _find_7z_exe to return None.
+        monkeypatch.setattr(archive, "_find_7z_exe", lambda: None)
+        # Create a fake .rar file (we never actually try to read it because
+        # _find_7z_exe is mocked to return None before the shell-out).
+        rar = tmp_path / "fake.rar"
+        rar.write_bytes(b"Rar!\x1a\x07\x00")  # RAR magic, content irrelevant
+        with pytest.raises(RuntimeError, match="7z_exe_not_found"):
+            archive.archive_extract_all({
+                "archive_path": str(rar),
+                "dest": str(tmp_path / "out"),
+            })
+
+    def test_extract_rar_routes_through_7z_exe_not_py7zr(self, tmp_path, monkeypatch):
+        """Asserts the .rar branch invokes 7z.exe and bypasses py7zr.
+
+        Without the fix, .rar fell into the (.7z, .rar) branch and py7zr
+        raised Bad7zFile. Mock _find_7z_exe + subprocess.run + the directory
+        walk to prove the routing without requiring a real RAR fixture.
+        """
+        seven_z_path = "/fake/7z.exe"
+        monkeypatch.setattr(archive, "_find_7z_exe", lambda: seven_z_path)
+
+        calls: list[tuple] = []
+
+        def _fake_list(seven_z, archive_path):
+            calls.append(("list", seven_z, str(archive_path)))
+            return ["only.txt"]
+
+        monkeypatch.setattr(archive, "_list_via_7z_exe", _fake_list)
+
+        class _FakeResult:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+
+        def _fake_run(cmd, **kwargs):
+            calls.append(("run", tuple(cmd)))
+            # Simulate extraction by creating the destination file. The
+            # -o<dest> argument is the only one starting with "-o".
+            dest_arg = next(a for a in cmd if a.startswith("-o"))
+            dest = Path(dest_arg[2:])
+            dest.mkdir(parents=True, exist_ok=True)
+            (dest / "only.txt").write_text("extracted from rar")
+            return _FakeResult()
+
+        monkeypatch.setattr(archive.subprocess, "run", _fake_run)
+
+        rar = tmp_path / "fake.rar"
+        rar.write_bytes(b"Rar!\x1a\x07\x00")
+        dest = tmp_path / "out"
+        result = archive.archive_extract_all({
+            "archive_path": str(rar),
+            "dest": str(dest),
+        })
+
+        assert result["format"] == "rar"
+        assert "only.txt" in result["files"]
+        assert (dest / "only.txt").read_text() == "extracted from rar"
+        # Prove the 7z.exe path was actually taken.
+        assert any(c[0] == "list" for c in calls), f"list step missing: {calls}"
+        assert any(c[0] == "run" and seven_z_path in c[1] for c in calls), f"7z.exe invocation missing: {calls}"
+
+    def test_extract_rar_propagates_7z_exit_code(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(archive, "_find_7z_exe", lambda: "/fake/7z.exe")
+        monkeypatch.setattr(archive, "_list_via_7z_exe", lambda _s, _a: [])
+
+        class _FakeResult:
+            returncode = 2  # 7z fatal exit
+            stderr = "Cannot open the file as archive"
+            stdout = ""
+
+        def _fake_run(cmd, **kwargs):
+            return _FakeResult()
+
+        monkeypatch.setattr(archive.subprocess, "run", _fake_run)
+        rar = tmp_path / "bad.rar"
+        rar.write_bytes(b"Rar!\x1a\x07\x00")
+        with pytest.raises(RuntimeError, match="7z_exe_failed: exit 2"):
+            archive.archive_extract_all({
+                "archive_path": str(rar),
+                "dest": str(tmp_path / "out"),
+            })

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/pipe-client.d.ts
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/pipe-client.d.ts
@@ -37,6 +37,24 @@ export declare class PipeClient {
      */
     call(method: string, payload: Record<string, unknown>, timeoutMs?: number): Promise<BrokerResponse>;
     /**
+     * Re-read endpoint.json and update the cached pipeName if it has changed.
+     *
+     * Used by `call()` to recover transparently when MO2 has been restarted
+     * since the original `discoverAndConnect`. We deliberately do NOT re-run
+     * the full discoverAndConnect cycle here:
+     *   - the broker publishes the new endpoint.json on every startup, so a
+     *     simple file read is enough to learn the new pipename;
+     *   - the full ping cycle would block every T3 dispatch in the steady-state
+     *     "pipe is still healthy" path, which is the overwhelming majority of
+     *     calls.
+     *
+     * If `endpoint.json` cannot be read (MO2 closed, plugin removed, IO
+     * race), this method silently returns; the subsequent `_rawCall` will
+     * fail normally and L1/L2 enrichment kicks in. This keeps the stale-pipe
+     * recovery best-effort and never adds a new failure mode.
+     */
+    _maybeRefreshStaleEndpoint(): Promise<void>;
+    /**
      * Raw broker call. Throws plain Error on timeout / empty / parse / socket
      * failure. Callers should prefer `call()` which adds L1+L2 enrichment;
      * `_rawCall` is exposed only for the in-class wrapping seam.

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/pipe-client.js
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/pipe-client.js
@@ -86,6 +86,19 @@ export class PipeClient {
         if (!this.pipeName) {
             throw new Error("pipe not discovered (call discoverAndConnect first)");
         }
+        // BUG-14 BUG-A (issue #14): lazy stale-pipe detection. The cached
+        // pipeName embeds the MO2 PID at the time of discoverAndConnect.
+        // If MO2 has been restarted since (new PID -> new broker pipe), this
+        // cached pipeName is dead and every T3 dispatch fails with
+        // `ENOENT \\.\pipe\mo2-control-plane-<oldPID>` even though MO2 is
+        // alive at a new PID. Re-read endpoint.json (fast: <1ms local file
+        // read) before each call; if the published endpoint differs from
+        // the cached pipeName, transparently auto-rebind. Without this,
+        // mo2_session reports `pipeConnected: true` (cached), but every
+        // mutating call silently routes to the dead pipe.
+        if (this.mo2Root) {
+            await this._maybeRefreshStaleEndpoint();
+        }
         const startedAt = Date.now();
         try {
             return await this._rawCall(method, payload, timeoutMs);
@@ -95,6 +108,40 @@ export class PipeClient {
             if (!this.mo2Root)
                 throw err;
             throw await enrichBrokerError(err, method, this.mo2Root, startedAt);
+        }
+    }
+    /**
+     * Re-read endpoint.json and update the cached pipeName if it has changed.
+     *
+     * Used by `call()` to recover transparently when MO2 has been restarted
+     * since the original `discoverAndConnect`. We deliberately do NOT re-run
+     * the full discoverAndConnect cycle here:
+     *   - the broker publishes the new endpoint.json on every startup, so a
+     *     simple file read is enough to learn the new pipename;
+     *   - the full ping cycle would block every T3 dispatch in the steady-state
+     *     "pipe is still healthy" path, which is the overwhelming majority of
+     *     calls.
+     *
+     * If `endpoint.json` cannot be read (MO2 closed, plugin removed, IO
+     * race), this method silently returns; the subsequent `_rawCall` will
+     * fail normally and L1/L2 enrichment kicks in. This keeps the stale-pipe
+     * recovery best-effort and never adds a new failure mode.
+     */
+    async _maybeRefreshStaleEndpoint() {
+        if (!this.mo2Root || !this.pipeName)
+            return;
+        const endpointPath = join(this.mo2Root, "plugins", "Mo2AgentControl", "bootstrap", "runtime", "endpoint.json");
+        let endpoint;
+        try {
+            endpoint = await readEndpoint(endpointPath, this.mo2Root);
+        }
+        catch {
+            return;
+        }
+        const currentPipeName = pipeNameOnly(endpoint.endpoint);
+        if (currentPipeName && currentPipeName !== this.pipeName) {
+            process.stderr.write(`[mo2-mcp] pipe endpoint changed (${this.pipeName} -> ${currentPipeName}); auto-rebinding\n`);
+            this.pipeName = currentPipeName;
         }
     }
     /**

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/plan-apply.d.ts
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/plan-apply.d.ts
@@ -33,9 +33,19 @@ export declare class PlanCache {
  * Handler that an individual T2/T3 tool implements.
  * - buildPlan: compute diff + affected files + lease targets
  * - applyMutation: execute the mutation given the validated plan
+ * - acquirePlanLock?: opt out of plan-time filesystem lease locking
+ *   (default true). When false, runPlanMode records the lease fingerprint
+ *   without acquiring a filesystem lock; runApplyMode acquires the lock
+ *   briefly at apply time, verifies the fingerprint, mutates, releases.
+ *   Use for tools whose plan phase is pure read and whose lease targets
+ *   are shared write surfaces (multiple plans for distinct mods that all
+ *   land in the same profile's modlist.txt / plugins.txt). BUG-14 BUG-F
+ *   (issue #14): mo2_install opts in so parallel plans for distinct
+ *   mod_names don't block each other.
  */
 export interface PlanApplyHandler {
     toolName: string;
+    acquirePlanLock?: boolean;
     buildPlan(args: Record<string, unknown>, ctx: ToolContext): Promise<{
         diff: string;
         affectedFiles: string[];

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/plan-apply.js
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/plan-apply.js
@@ -68,32 +68,42 @@ export async function runPlanMode(handler, args, ctx, cache, _snapshots) {
     const planId = randomUUID();
     const expiresAt = Date.now() + LEASE_LOCK_TTL_MS;
     const createdAt = new Date().toISOString();
-    const lock = await acquireLeasesForTargets(requireBoundContext(ctx).config.mo2Root, built.targets, {
-        plan_id: planId,
-        mcp_pid: process.pid,
-        mcp_session_id: ctx.sessionId,
-        lease_token: lease.token,
-        tool_name: handler.toolName,
-        created_at: createdAt,
-        expires_at: new Date(expiresAt).toISOString(),
-    });
-    if (!lock.acquired) {
-        const holders = lock.holders.map((holder) => ({
-            tool: holder.tool_name,
-            tool_name: holder.tool_name,
-            mcp_pid: holder.mcp_pid,
-            created_at: holder.created_at,
-        }));
-        const firstHolder = holders[0];
-        return {
-            ok: false,
-            error: {
-                code: "lease_held",
-                message: `Target is already locked by ${firstHolder.tool_name} in MCP process ${firstHolder.mcp_pid}`,
-                holder: firstHolder,
-                holders,
-            },
-        };
+    // BUG-14 BUG-F (issue #14): handlers may opt to defer lease lock
+    // acquisition to apply time so plan-only operations can run
+    // concurrently against shared write surfaces. When deferred, plan
+    // returns without acquiring any filesystem lock; runApplyMode picks
+    // it up at apply boundary.
+    const lockAtPlan = handler.acquirePlanLock !== false;
+    let leaseLockTargetHashes = [];
+    if (lockAtPlan) {
+        const lock = await acquireLeasesForTargets(requireBoundContext(ctx).config.mo2Root, built.targets, {
+            plan_id: planId,
+            mcp_pid: process.pid,
+            mcp_session_id: ctx.sessionId,
+            lease_token: lease.token,
+            tool_name: handler.toolName,
+            created_at: createdAt,
+            expires_at: new Date(expiresAt).toISOString(),
+        });
+        if (!lock.acquired) {
+            const holders = lock.holders.map((holder) => ({
+                tool: holder.tool_name,
+                tool_name: holder.tool_name,
+                mcp_pid: holder.mcp_pid,
+                created_at: holder.created_at,
+            }));
+            const firstHolder = holders[0];
+            return {
+                ok: false,
+                error: {
+                    code: "lease_held",
+                    message: `Target is already locked by ${firstHolder.tool_name} in MCP process ${firstHolder.mcp_pid}`,
+                    holder: firstHolder,
+                    holders,
+                },
+            };
+        }
+        leaseLockTargetHashes = lock.targetHashes;
     }
     let rec;
     try {
@@ -105,11 +115,13 @@ export async function runPlanMode(handler, args, ctx, cache, _snapshots) {
             diff: built.diff,
             affectedFiles: built.affectedFiles,
             lease,
-            leaseLockTargetHashes: lock.targetHashes,
+            leaseLockTargetHashes,
         });
     }
     catch (error) {
-        await releaseLeaseLocks(requireBoundContext(ctx).config.mo2Root, lock.targetHashes, planId);
+        if (lockAtPlan) {
+            await releaseLeaseLocks(requireBoundContext(ctx).config.mo2Root, leaseLockTargetHashes, planId);
+        }
         throw error;
     }
     return {
@@ -145,6 +157,45 @@ export async function runApplyMode(handler, args, ctx, cache, snapshots) {
                 message: "stored plan lease differs from supplied",
             },
         };
+    }
+    // BUG-14 BUG-F (issue #14): when the handler opted out of plan-time
+    // locking, acquire the filesystem lock here at the apply boundary.
+    // Concurrent applies serialize naturally; the lease verification
+    // immediately below catches any drift that happened between this
+    // plan's generation and the moment the lock was acquired.
+    if (handler.acquirePlanLock === false) {
+        const lock = await acquireLeasesForTargets(requireBoundContext(ctx).config.mo2Root, rec.lease.components.map((component) => ({
+            path: component.path,
+            kind: component.kind,
+        })), {
+            plan_id: rec.planId,
+            mcp_pid: process.pid,
+            mcp_session_id: ctx.sessionId,
+            lease_token: rec.lease.token,
+            tool_name: handler.toolName,
+            created_at: new Date().toISOString(),
+            expires_at: new Date(rec.expiresAt).toISOString(),
+        });
+        if (!lock.acquired) {
+            const holders = lock.holders.map((holder) => ({
+                tool: holder.tool_name,
+                tool_name: holder.tool_name,
+                mcp_pid: holder.mcp_pid,
+                created_at: holder.created_at,
+            }));
+            const firstHolder = holders[0];
+            return {
+                ok: false,
+                error: {
+                    code: "lease_held",
+                    message: `Target is already locked by ${firstHolder.tool_name} in MCP process ${firstHolder.mcp_pid}`,
+                    // ApplyResult's error shape is generic; pass holder details in
+                    // a side-channel-compatible field so callers can introspect.
+                    drift: { holder: firstHolder, holders },
+                },
+            };
+        }
+        rec.leaseLockTargetHashes = lock.targetHashes;
     }
     const v = await verifyLease(rec.lease);
     if (!v.valid) {

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/tools/mo2-install.js
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/tools/mo2-install.js
@@ -20,7 +20,7 @@
 import { z } from "zod";
 import { readFile, mkdir, rename, cp, readdir, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { join, basename } from "node:path";
+import { join, basename, extname, dirname } from "node:path";
 import { randomUUID } from "node:crypto";
 import { registerTool } from "../tool-registry.js";
 import { routeToPlanApply } from "../plan-apply.js";
@@ -62,6 +62,151 @@ async function _copyDirectoryContents(sourceDir, destDir) {
         await cp(join(sourceDir, entry.name), join(destDir, entry.name), { recursive: true });
     }
 }
+// BUG-14 BUG-D (issue #14): BGS mod archives commonly wrap content in a
+// top-level `Data/` directory (per BGS convention), or a `<modname>/`
+// wrapper, or both. MO2's GUI installer flattens these so the plugin
+// lands at `mods/<modname>/<plugin>.esm`, not at
+// `mods/<modname>/Data/<plugin>.esm`. Without flattening, MO2's VFS
+// projects the file as `<game>/Data/Data/<plugin>.esm` and the engine
+// silently cannot find it.
+//
+// Heuristic, in priority order:
+//  1. Plugin file (.esm/.esp/.esl) at this level → this is the mod root.
+//  2. Known BGS asset directory (meshes, textures, scripts, fomod, sfse,
+//     f4se, skse, etc.) at this level → mod root (asset-only mods are
+//     valid; no plugin required).
+//  3. Single subdirectory and no hits at this level → recurse into it
+//     (handles the common Data/ and ModName/Data/ wrappers).
+//  4. Anything else (multiple subdirs without plugins or asset markers)
+//     → ambiguous, leave layout as-is.
+//
+// Depth is capped at 4 to avoid pathological extracts. The original
+// staging dir itself is never removed (it's the destination).
+const _PLUGIN_EXTS = new Set([".esm", ".esp", ".esl"]);
+const _BGS_ASSET_DIRS = new Set([
+    // BGS-standard
+    "meshes",
+    "textures",
+    "sound",
+    "music",
+    "materials",
+    "scripts",
+    "interface",
+    "seq",
+    "video",
+    "lodsettings",
+    "shadersfx",
+    "strings",
+    // Installer & xSE
+    "fomod",
+    "f4se",
+    "skse",
+    "skse64",
+    "sfse",
+    "obse",
+    "fose",
+    "nvse",
+    // Misc engine roots that show up in real archives
+    "platform",
+    "menus",
+]);
+async function _findBgsModRoot(dir, depth, maxDepth = 4) {
+    if (depth > maxDepth)
+        return null;
+    let entries;
+    try {
+        entries = await readdir(dir, { withFileTypes: true });
+    }
+    catch {
+        return null;
+    }
+    for (const entry of entries) {
+        if (entry.isFile() && _PLUGIN_EXTS.has(extname(entry.name).toLowerCase())) {
+            return dir;
+        }
+    }
+    for (const entry of entries) {
+        if (entry.isDirectory() && _BGS_ASSET_DIRS.has(entry.name.toLowerCase())) {
+            return dir;
+        }
+    }
+    const subdirs = entries.filter((e) => e.isDirectory());
+    if (subdirs.length === 1) {
+        return _findBgsModRoot(join(dir, subdirs[0].name), depth + 1, maxDepth);
+    }
+    return null;
+}
+async function _flattenBgsArchive(stagingDir) {
+    const root = await _findBgsModRoot(stagingDir, 0);
+    if (!root || root === stagingDir)
+        return { flattened: false };
+    // Move root's entries up to stagingDir, then clean the now-empty
+    // intermediate directories. Two-pass: first read, then rename.
+    const rootEntries = await readdir(root);
+    for (const name of rootEntries) {
+        await rename(join(root, name), join(stagingDir, name));
+    }
+    // Walk the chain from `root` back up to stagingDir's child and rm each
+    // emptied dir. dirname() loop stops once we reach stagingDir.
+    let cleanup = root;
+    while (cleanup && cleanup !== stagingDir) {
+        try {
+            await rm(cleanup, { recursive: true, force: true });
+        }
+        catch {
+            break;
+        }
+        const parent = dirname(cleanup);
+        if (parent === cleanup)
+            break;
+        cleanup = parent === stagingDir ? null : parent;
+    }
+    return { flattened: true, from: root };
+}
+// BUG-14 BUG-E (issue #14): enumerate plugin files at the final mod root
+// and register them in the profile's plugins.txt. Without this, every
+// install completed "successfully" but the mod's plugins stayed inactive
+// — the agent had to do a separate enumeration + N×toggle_plugin calls
+// to actually activate them.
+//
+// Behavior matches MO2 GUI's "Install Mod from Archive": newly-installed
+// plugins land enabled (asterisk prefix in plugins.txt per FO4/SSE
+// convention). Existing entries (case-insensitive match) are preserved
+// — we never overwrite a disabled plugin's state.
+async function _registerPluginsInPluginsTxt(modRoot, pluginsTxtPath) {
+    let modEntries;
+    try {
+        modEntries = await readdir(modRoot, { withFileTypes: true });
+    }
+    catch {
+        return [];
+    }
+    const newPlugins = modEntries
+        .filter((e) => e.isFile() && _PLUGIN_EXTS.has(extname(e.name).toLowerCase()))
+        .map((e) => e.name)
+        .sort();
+    if (newPlugins.length === 0)
+        return [];
+    const existingTxt = await readFile(pluginsTxtPath, "utf8").catch(() => "");
+    const existingLower = new Set(existingTxt
+        .split(/\r?\n/)
+        .filter((line) => line.length > 0 && !line.startsWith("#"))
+        .map((line) => line.replace(/^\*/, "").trim().toLowerCase()));
+    const linesToAdd = [];
+    const registered = [];
+    for (const plugin of newPlugins) {
+        if (!existingLower.has(plugin.toLowerCase())) {
+            linesToAdd.push(`*${plugin}`);
+            registered.push(plugin);
+        }
+    }
+    if (linesToAdd.length === 0)
+        return [];
+    const sep = existingTxt.length === 0 || existingTxt.endsWith("\n") ? "" : "\n";
+    const newTxt = `${existingTxt}${sep}${linesToAdd.join("\n")}\n`;
+    await atomicWriteText(pluginsTxtPath, newTxt);
+    return registered;
+}
 // FOMOD detection + choices-shape helpers were extracted into
 // ../fomod-helpers.ts (2026-06-17 v1.2 Batch 4 Lane 4C) so mo2_reinstall_mod
 // can share the same contract with the sidecar instead of carrying a parallel
@@ -69,6 +214,12 @@ async function _copyDirectoryContents(sourceDir, destDir) {
 // substring contract and the empty-array=no-choices semantics (BUG-19 fix).
 const handler = {
     toolName: "mo2_install",
+    // BUG-14 BUG-F (issue #14): defer lease lock to apply time so parallel
+    // plans for distinct mod_names don't contend on shared modlist.txt /
+    // plugins.txt lease targets. The fingerprint stored at plan time still
+    // catches inter-plan drift; apply-time lock acquisition serializes the
+    // actual mutations.
+    acquirePlanLock: false,
     async buildPlan(args, ctx) {
         const bound = requireBoundContext(ctx);
         if (!bound.sidecar) {
@@ -103,10 +254,18 @@ const handler = {
         }
         const profileDir = resolveProfileDir(ctx, profile);
         const modlistPath = join(profileDir, "modlist.txt");
+        // BUG-14 BUG-E (issue #14): track plugins.txt as an affected file so
+        // the snapshot taken at apply time captures its pre-write state and
+        // rollback can restore it. Lease target as well so concurrent installs
+        // detect plugins.txt drift between plan and apply.
+        const pluginsTxtPath = join(profileDir, "plugins.txt");
         return {
             diff: `Install ${modName} (FOMOD=${isFomod}, target_priority=${String(args.target_priority)})`,
-            affectedFiles: [destPath, modlistPath],
-            targets: [{ path: modlistPath, kind: "text-file" }],
+            affectedFiles: [destPath, modlistPath, pluginsTxtPath],
+            targets: [
+                { path: modlistPath, kind: "text-file" },
+                { path: pluginsTxtPath, kind: "text-file" },
+            ],
         };
     },
     async applyMutation(plan, ctx) {
@@ -141,6 +300,12 @@ const handler = {
                 archive_path: archivePath,
                 dest: stagingDir,
             });
+            // BUG-14 BUG-D: flatten common BGS archive wrapper patterns
+            // (Data/, ModName/, ModName/Data/) so the plugin and assets land
+            // at the mod folder root, not inside a Data/ subdir that MO2's
+            // VFS would double-prefix. FOMOD-staged installs already map
+            // source→destination explicitly so they don't need this pass.
+            await _flattenBgsArchive(stagingDir);
         }
         // 2. Live broker createMod creates the destination directory itself; copy
         // staged contents into that broker-returned path. Offline path owns the
@@ -200,7 +365,8 @@ const handler = {
         ].join("\n");
         await atomicWriteText(join(finalDestPath, "meta.ini"), meta + "\n");
         // 4. Register in modlist.txt.
-        const modlistPath = join(resolveProfileDir(ctx, profile), "modlist.txt");
+        const profileDir = resolveProfileDir(ctx, profile);
+        const modlistPath = join(profileDir, "modlist.txt");
         const existing = await readFile(modlistPath, "utf8").catch(() => "");
         const newLine = `+${modName}`;
         const lines = existing.length === 0 ? [] : existing.split(/\r?\n/).filter((line) => line.length > 0);
@@ -210,13 +376,32 @@ const handler = {
                 : `${existing}${existing.endsWith("\n") || existing.length === 0 ? "" : "\n"}${newLine}\n`;
             await atomicWriteText(modlistPath, updated);
         }
-        // 5. Invalidate sidecar World cache so subsequent asset reads see the new mod.
+        // 5. BUG-14 BUG-E: register fresh-install plugins in plugins.txt.
+        // Before this fix, every mo2_install completed "successfully" but
+        // the mod's plugins stayed inactive — the agent had to do a separate
+        // enumeration + N×toggle_plugin calls to actually activate them.
+        const pluginsTxtPath = join(profileDir, "plugins.txt");
+        const pluginsRegistered = await _registerPluginsInPluginsTxt(finalDestPath, pluginsTxtPath);
+        // 6. If live broker is up, ask MO2 to re-scan so the freshly-written
+        // plugins.txt rows become active in MO2's in-memory plugin list.
+        // Best-effort: ignore failures (the file write already took, and
+        // MO2 will see it on next user-driven refresh either way).
+        if (pluginsRegistered.length > 0 && bound.pipeClient) {
+            try {
+                await bound.pipeClient.call("organizer.refresh", { save_changes: false });
+            }
+            catch {
+                // swallowed: see comment above
+            }
+        }
+        // 7. Invalidate sidecar World cache so subsequent asset reads see the new mod.
         await invalidateWorld(ctx, [profile]);
         return {
             mod_name: modName,
             dest_path: finalDestPath,
             fomod_used: useFomodChoices,
             installation_file: basename(archivePath),
+            plugins_registered: pluginsRegistered,
         };
     },
 };

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/tools/mo2-send-mod-to.js
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/tools/mo2-send-mod-to.js
@@ -45,9 +45,28 @@ async function _computeTargetPriority(args, ctx, profile) {
     const p = await readProfile(join(bound.config.mo2Root, "profiles", profile));
     const nonSep = p.mods.filter((m) => !m.isSeparator);
     const mode = args.target_mode;
+    // BUG-14 BUG-B fix (issue #14): the broker's `mods.set_priority`
+    // validates `priority <= len(non_separator_mods)` and then calls
+    // mobase.IModList.setPriority in non-separator priority space.
+    // `profile-reader.ts` assigns priorities from the FULL modlist.txt
+    // line count (which includes separators). So a value computed in
+    // full-priority space (e.g. `sep.priority + 1`) overshoots the
+    // broker validator whenever separators occupy upper slots — the
+    // real-world BB84 case: separator at full priority 391 with 30
+    // separators above produced plan→392, broker rejected with
+    // "priority 392 out of [0..375]".
+    //
+    // Convert via `nonSepRank(fullPrio)` = count of non-separator mods
+    // strictly below `fullPrio` in full-priority space. That count is
+    // exactly the non-separator slot just above the given full-prio
+    // position. Clamp to [0, nonSep.length - 1] to stay within broker
+    // bounds.
+    const nonSepRank = (fullPrio) => nonSep.filter((m) => m.priority < fullPrio).length;
+    const maxNonSepPri = Math.max(0, nonSep.length - 1);
+    const clamp = (v) => Math.max(0, Math.min(v, maxNonSepPri));
     switch (mode) {
         case "top":
-            return Math.max(nonSep.length - 1, 0);
+            return maxNonSepPri;
         case "bottom":
             return 0;
         case "priority":
@@ -56,7 +75,7 @@ async function _computeTargetPriority(args, ctx, profile) {
             const sep = p.mods.find((m) => m.isSeparator && m.name === args.target_separator);
             if (!sep)
                 throw new Error(`separator_not_found: ${args.target_separator}`);
-            return sep.priority + 1;
+            return clamp(nonSepRank(sep.priority));
         }
         case "above_first_conflict":
         case "below_last_conflict": {
@@ -74,11 +93,16 @@ async function _computeTargetPriority(args, ctx, profile) {
             if (conflictMods.length === 0) {
                 throw new Error("no_conflicts_found");
             }
-            const conflictPriorities = conflictMods
-                .map((n) => p.mods.find((m) => m.name === n)?.priority ?? 0);
+            const conflictRanks = conflictMods
+                .map((n) => p.mods.find((m) => m.name === n))
+                .filter((m) => m !== undefined && !m.isSeparator)
+                .map((m) => nonSepRank(m.priority));
+            if (conflictRanks.length === 0) {
+                throw new Error("no_conflicts_found");
+            }
             if (mode === "above_first_conflict")
-                return Math.max(...conflictPriorities) + 1;
-            return Math.max(Math.min(...conflictPriorities) - 1, 0);
+                return clamp(Math.max(...conflictRanks) + 1);
+            return clamp(Math.min(...conflictRanks) - 1);
         }
         default:
             throw new Error(`unknown_mode: ${mode}`);

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/src/pipe-client.ts
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/src/pipe-client.ts
@@ -112,6 +112,19 @@ export class PipeClient {
     if (!this.pipeName) {
       throw new Error("pipe not discovered (call discoverAndConnect first)");
     }
+    // BUG-14 BUG-A (issue #14): lazy stale-pipe detection. The cached
+    // pipeName embeds the MO2 PID at the time of discoverAndConnect.
+    // If MO2 has been restarted since (new PID -> new broker pipe), this
+    // cached pipeName is dead and every T3 dispatch fails with
+    // `ENOENT \\.\pipe\mo2-control-plane-<oldPID>` even though MO2 is
+    // alive at a new PID. Re-read endpoint.json (fast: <1ms local file
+    // read) before each call; if the published endpoint differs from
+    // the cached pipeName, transparently auto-rebind. Without this,
+    // mo2_session reports `pipeConnected: true` (cached), but every
+    // mutating call silently routes to the dead pipe.
+    if (this.mo2Root) {
+      await this._maybeRefreshStaleEndpoint();
+    }
     const startedAt = Date.now();
     try {
       return await this._rawCall(method, payload, timeoutMs);
@@ -119,6 +132,48 @@ export class PipeClient {
       // No mo2Root means we can't drive the enrichment probes; rethrow raw.
       if (!this.mo2Root) throw err;
       throw await enrichBrokerError(err, method, this.mo2Root, startedAt);
+    }
+  }
+
+  /**
+   * Re-read endpoint.json and update the cached pipeName if it has changed.
+   *
+   * Used by `call()` to recover transparently when MO2 has been restarted
+   * since the original `discoverAndConnect`. We deliberately do NOT re-run
+   * the full discoverAndConnect cycle here:
+   *   - the broker publishes the new endpoint.json on every startup, so a
+   *     simple file read is enough to learn the new pipename;
+   *   - the full ping cycle would block every T3 dispatch in the steady-state
+   *     "pipe is still healthy" path, which is the overwhelming majority of
+   *     calls.
+   *
+   * If `endpoint.json` cannot be read (MO2 closed, plugin removed, IO
+   * race), this method silently returns; the subsequent `_rawCall` will
+   * fail normally and L1/L2 enrichment kicks in. This keeps the stale-pipe
+   * recovery best-effort and never adds a new failure mode.
+   */
+  async _maybeRefreshStaleEndpoint(): Promise<void> {
+    if (!this.mo2Root || !this.pipeName) return;
+    const endpointPath = join(
+      this.mo2Root,
+      "plugins",
+      "Mo2AgentControl",
+      "bootstrap",
+      "runtime",
+      "endpoint.json",
+    );
+    let endpoint: EndpointFile;
+    try {
+      endpoint = await readEndpoint(endpointPath, this.mo2Root);
+    } catch {
+      return;
+    }
+    const currentPipeName = pipeNameOnly(endpoint.endpoint);
+    if (currentPipeName && currentPipeName !== this.pipeName) {
+      process.stderr.write(
+        `[mo2-mcp] pipe endpoint changed (${this.pipeName} -> ${currentPipeName}); auto-rebinding\n`,
+      );
+      this.pipeName = currentPipeName;
     }
   }
 

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/src/plan-apply.ts
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/src/plan-apply.ts
@@ -91,9 +91,19 @@ export class PlanCache {
  * Handler that an individual T2/T3 tool implements.
  * - buildPlan: compute diff + affected files + lease targets
  * - applyMutation: execute the mutation given the validated plan
+ * - acquirePlanLock?: opt out of plan-time filesystem lease locking
+ *   (default true). When false, runPlanMode records the lease fingerprint
+ *   without acquiring a filesystem lock; runApplyMode acquires the lock
+ *   briefly at apply time, verifies the fingerprint, mutates, releases.
+ *   Use for tools whose plan phase is pure read and whose lease targets
+ *   are shared write surfaces (multiple plans for distinct mods that all
+ *   land in the same profile's modlist.txt / plugins.txt). BUG-14 BUG-F
+ *   (issue #14): mo2_install opts in so parallel plans for distinct
+ *   mod_names don't block each other.
  */
 export interface PlanApplyHandler {
   toolName: string;
+  acquirePlanLock?: boolean;
   buildPlan(
     args: Record<string, unknown>,
     ctx: ToolContext,
@@ -168,33 +178,49 @@ export async function runPlanMode(
   const planId = randomUUID();
   const expiresAt = Date.now() + LEASE_LOCK_TTL_MS;
   const createdAt = new Date().toISOString();
-  const lock = await acquireLeasesForTargets(requireBoundContext(ctx).config.mo2Root, built.targets, {
-    plan_id: planId,
-    mcp_pid: process.pid,
-    mcp_session_id: ctx.sessionId,
-    lease_token: lease.token,
-    tool_name: handler.toolName,
-    created_at: createdAt,
-    expires_at: new Date(expiresAt).toISOString(),
-  });
-  if (!lock.acquired) {
-    const holders = lock.holders.map((holder) => ({
-      tool: holder.tool_name,
-      tool_name: holder.tool_name,
-      mcp_pid: holder.mcp_pid,
-      created_at: holder.created_at,
-    }));
-    const firstHolder = holders[0];
-    return {
-      ok: false,
-      error: {
-        code: "lease_held",
-        message: `Target is already locked by ${firstHolder.tool_name} in MCP process ${firstHolder.mcp_pid}`,
-        holder: firstHolder,
-        holders,
+
+  // BUG-14 BUG-F (issue #14): handlers may opt to defer lease lock
+  // acquisition to apply time so plan-only operations can run
+  // concurrently against shared write surfaces. When deferred, plan
+  // returns without acquiring any filesystem lock; runApplyMode picks
+  // it up at apply boundary.
+  const lockAtPlan = handler.acquirePlanLock !== false;
+  let leaseLockTargetHashes: string[] = [];
+  if (lockAtPlan) {
+    const lock = await acquireLeasesForTargets(
+      requireBoundContext(ctx).config.mo2Root,
+      built.targets,
+      {
+        plan_id: planId,
+        mcp_pid: process.pid,
+        mcp_session_id: ctx.sessionId,
+        lease_token: lease.token,
+        tool_name: handler.toolName,
+        created_at: createdAt,
+        expires_at: new Date(expiresAt).toISOString(),
       },
-    };
+    );
+    if (!lock.acquired) {
+      const holders = lock.holders.map((holder) => ({
+        tool: holder.tool_name,
+        tool_name: holder.tool_name,
+        mcp_pid: holder.mcp_pid,
+        created_at: holder.created_at,
+      }));
+      const firstHolder = holders[0];
+      return {
+        ok: false,
+        error: {
+          code: "lease_held",
+          message: `Target is already locked by ${firstHolder.tool_name} in MCP process ${firstHolder.mcp_pid}`,
+          holder: firstHolder,
+          holders,
+        },
+      };
+    }
+    leaseLockTargetHashes = lock.targetHashes;
   }
+
   let rec: PlanRecord;
   try {
     rec = cache.store({
@@ -205,10 +231,16 @@ export async function runPlanMode(
       diff: built.diff,
       affectedFiles: built.affectedFiles,
       lease,
-      leaseLockTargetHashes: lock.targetHashes,
+      leaseLockTargetHashes,
     });
   } catch (error) {
-    await releaseLeaseLocks(requireBoundContext(ctx).config.mo2Root, lock.targetHashes, planId);
+    if (lockAtPlan) {
+      await releaseLeaseLocks(
+        requireBoundContext(ctx).config.mo2Root,
+        leaseLockTargetHashes,
+        planId,
+      );
+    }
     throw error;
   }
   return {
@@ -262,6 +294,51 @@ export async function runApplyMode(
       },
     };
   }
+
+  // BUG-14 BUG-F (issue #14): when the handler opted out of plan-time
+  // locking, acquire the filesystem lock here at the apply boundary.
+  // Concurrent applies serialize naturally; the lease verification
+  // immediately below catches any drift that happened between this
+  // plan's generation and the moment the lock was acquired.
+  if (handler.acquirePlanLock === false) {
+    const lock = await acquireLeasesForTargets(
+      requireBoundContext(ctx).config.mo2Root,
+      rec.lease.components.map((component) => ({
+        path: component.path,
+        kind: component.kind,
+      })),
+      {
+        plan_id: rec.planId,
+        mcp_pid: process.pid,
+        mcp_session_id: ctx.sessionId,
+        lease_token: rec.lease.token,
+        tool_name: handler.toolName,
+        created_at: new Date().toISOString(),
+        expires_at: new Date(rec.expiresAt).toISOString(),
+      },
+    );
+    if (!lock.acquired) {
+      const holders = lock.holders.map((holder) => ({
+        tool: holder.tool_name,
+        tool_name: holder.tool_name,
+        mcp_pid: holder.mcp_pid,
+        created_at: holder.created_at,
+      }));
+      const firstHolder = holders[0];
+      return {
+        ok: false,
+        error: {
+          code: "lease_held",
+          message: `Target is already locked by ${firstHolder.tool_name} in MCP process ${firstHolder.mcp_pid}`,
+          // ApplyResult's error shape is generic; pass holder details in
+          // a side-channel-compatible field so callers can introspect.
+          drift: { holder: firstHolder, holders },
+        },
+      };
+    }
+    rec.leaseLockTargetHashes = lock.targetHashes;
+  }
+
   const v = await verifyLease(rec.lease);
   if (!v.valid) {
     await releasePlanLockBestEffort(ctx, rec);

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/src/tools/mo2-install.ts
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/src/tools/mo2-install.ts
@@ -20,7 +20,7 @@
 import { z } from "zod";
 import { readFile, mkdir, rename, cp, readdir, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { join, basename } from "node:path";
+import { join, basename, extname, dirname } from "node:path";
 import { randomUUID } from "node:crypto";
 import { registerTool } from "../tool-registry.js";
 import { routeToPlanApply, type PlanApplyHandler } from "../plan-apply.js";
@@ -68,6 +68,155 @@ async function _copyDirectoryContents(sourceDir: string, destDir: string): Promi
   }
 }
 
+// BUG-14 BUG-D (issue #14): BGS mod archives commonly wrap content in a
+// top-level `Data/` directory (per BGS convention), or a `<modname>/`
+// wrapper, or both. MO2's GUI installer flattens these so the plugin
+// lands at `mods/<modname>/<plugin>.esm`, not at
+// `mods/<modname>/Data/<plugin>.esm`. Without flattening, MO2's VFS
+// projects the file as `<game>/Data/Data/<plugin>.esm` and the engine
+// silently cannot find it.
+//
+// Heuristic, in priority order:
+//  1. Plugin file (.esm/.esp/.esl) at this level → this is the mod root.
+//  2. Known BGS asset directory (meshes, textures, scripts, fomod, sfse,
+//     f4se, skse, etc.) at this level → mod root (asset-only mods are
+//     valid; no plugin required).
+//  3. Single subdirectory and no hits at this level → recurse into it
+//     (handles the common Data/ and ModName/Data/ wrappers).
+//  4. Anything else (multiple subdirs without plugins or asset markers)
+//     → ambiguous, leave layout as-is.
+//
+// Depth is capped at 4 to avoid pathological extracts. The original
+// staging dir itself is never removed (it's the destination).
+const _PLUGIN_EXTS = new Set([".esm", ".esp", ".esl"]);
+const _BGS_ASSET_DIRS = new Set([
+  // BGS-standard
+  "meshes",
+  "textures",
+  "sound",
+  "music",
+  "materials",
+  "scripts",
+  "interface",
+  "seq",
+  "video",
+  "lodsettings",
+  "shadersfx",
+  "strings",
+  // Installer & xSE
+  "fomod",
+  "f4se",
+  "skse",
+  "skse64",
+  "sfse",
+  "obse",
+  "fose",
+  "nvse",
+  // Misc engine roots that show up in real archives
+  "platform",
+  "menus",
+]);
+
+async function _findBgsModRoot(dir: string, depth: number, maxDepth = 4): Promise<string | null> {
+  if (depth > maxDepth) return null;
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    if (entry.isFile() && _PLUGIN_EXTS.has(extname(entry.name).toLowerCase())) {
+      return dir;
+    }
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory() && _BGS_ASSET_DIRS.has(entry.name.toLowerCase())) {
+      return dir;
+    }
+  }
+  const subdirs = entries.filter((e) => e.isDirectory());
+  if (subdirs.length === 1) {
+    return _findBgsModRoot(join(dir, subdirs[0].name), depth + 1, maxDepth);
+  }
+  return null;
+}
+
+async function _flattenBgsArchive(stagingDir: string): Promise<{ flattened: boolean; from?: string }> {
+  const root = await _findBgsModRoot(stagingDir, 0);
+  if (!root || root === stagingDir) return { flattened: false };
+  // Move root's entries up to stagingDir, then clean the now-empty
+  // intermediate directories. Two-pass: first read, then rename.
+  const rootEntries = await readdir(root);
+  for (const name of rootEntries) {
+    await rename(join(root, name), join(stagingDir, name));
+  }
+  // Walk the chain from `root` back up to stagingDir's child and rm each
+  // emptied dir. dirname() loop stops once we reach stagingDir.
+  let cleanup: string | null = root;
+  while (cleanup && cleanup !== stagingDir) {
+    try {
+      await rm(cleanup, { recursive: true, force: true });
+    } catch {
+      break;
+    }
+    const parent = dirname(cleanup);
+    if (parent === cleanup) break;
+    cleanup = parent === stagingDir ? null : parent;
+  }
+  return { flattened: true, from: root };
+}
+
+// BUG-14 BUG-E (issue #14): enumerate plugin files at the final mod root
+// and register them in the profile's plugins.txt. Without this, every
+// install completed "successfully" but the mod's plugins stayed inactive
+// — the agent had to do a separate enumeration + N×toggle_plugin calls
+// to actually activate them.
+//
+// Behavior matches MO2 GUI's "Install Mod from Archive": newly-installed
+// plugins land enabled (asterisk prefix in plugins.txt per FO4/SSE
+// convention). Existing entries (case-insensitive match) are preserved
+// — we never overwrite a disabled plugin's state.
+async function _registerPluginsInPluginsTxt(
+  modRoot: string,
+  pluginsTxtPath: string,
+): Promise<string[]> {
+  let modEntries: import("node:fs").Dirent[];
+  try {
+    modEntries = await readdir(modRoot, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const newPlugins = modEntries
+    .filter((e) => e.isFile() && _PLUGIN_EXTS.has(extname(e.name).toLowerCase()))
+    .map((e) => e.name)
+    .sort();
+  if (newPlugins.length === 0) return [];
+
+  const existingTxt = await readFile(pluginsTxtPath, "utf8").catch(() => "");
+  const existingLower = new Set(
+    existingTxt
+      .split(/\r?\n/)
+      .filter((line) => line.length > 0 && !line.startsWith("#"))
+      .map((line) => line.replace(/^\*/, "").trim().toLowerCase()),
+  );
+
+  const linesToAdd: string[] = [];
+  const registered: string[] = [];
+  for (const plugin of newPlugins) {
+    if (!existingLower.has(plugin.toLowerCase())) {
+      linesToAdd.push(`*${plugin}`);
+      registered.push(plugin);
+    }
+  }
+  if (linesToAdd.length === 0) return [];
+
+  const sep = existingTxt.length === 0 || existingTxt.endsWith("\n") ? "" : "\n";
+  const newTxt = `${existingTxt}${sep}${linesToAdd.join("\n")}\n`;
+  await atomicWriteText(pluginsTxtPath, newTxt);
+  return registered;
+}
+
 // FOMOD detection + choices-shape helpers were extracted into
 // ../fomod-helpers.ts (2026-06-17 v1.2 Batch 4 Lane 4C) so mo2_reinstall_mod
 // can share the same contract with the sidecar instead of carrying a parallel
@@ -76,6 +225,12 @@ async function _copyDirectoryContents(sourceDir: string, destDir: string): Promi
 
 const handler: PlanApplyHandler = {
   toolName: "mo2_install",
+  // BUG-14 BUG-F (issue #14): defer lease lock to apply time so parallel
+  // plans for distinct mod_names don't contend on shared modlist.txt /
+  // plugins.txt lease targets. The fingerprint stored at plan time still
+  // catches inter-plan drift; apply-time lock acquisition serializes the
+  // actual mutations.
+  acquirePlanLock: false,
   async buildPlan(args, ctx) {
     const bound = requireBoundContext(ctx);
     if (!bound.sidecar) {
@@ -117,11 +272,19 @@ const handler: PlanApplyHandler = {
 
     const profileDir = resolveProfileDir(ctx, profile);
     const modlistPath = join(profileDir, "modlist.txt");
+    // BUG-14 BUG-E (issue #14): track plugins.txt as an affected file so
+    // the snapshot taken at apply time captures its pre-write state and
+    // rollback can restore it. Lease target as well so concurrent installs
+    // detect plugins.txt drift between plan and apply.
+    const pluginsTxtPath = join(profileDir, "plugins.txt");
 
     return {
       diff: `Install ${modName} (FOMOD=${isFomod}, target_priority=${String(args.target_priority)})`,
-      affectedFiles: [destPath, modlistPath],
-      targets: [{ path: modlistPath, kind: "text-file" }],
+      affectedFiles: [destPath, modlistPath, pluginsTxtPath],
+      targets: [
+        { path: modlistPath, kind: "text-file" },
+        { path: pluginsTxtPath, kind: "text-file" },
+      ],
     };
   },
 
@@ -157,6 +320,12 @@ const handler: PlanApplyHandler = {
         archive_path: archivePath,
         dest: stagingDir,
       });
+      // BUG-14 BUG-D: flatten common BGS archive wrapper patterns
+      // (Data/, ModName/, ModName/Data/) so the plugin and assets land
+      // at the mod folder root, not inside a Data/ subdir that MO2's
+      // VFS would double-prefix. FOMOD-staged installs already map
+      // source→destination explicitly so they don't need this pass.
+      await _flattenBgsArchive(stagingDir);
     }
 
     // 2. Live broker createMod creates the destination directory itself; copy
@@ -216,7 +385,8 @@ const handler: PlanApplyHandler = {
     await atomicWriteText(join(finalDestPath, "meta.ini"), meta + "\n");
 
     // 4. Register in modlist.txt.
-    const modlistPath = join(resolveProfileDir(ctx, profile), "modlist.txt");
+    const profileDir = resolveProfileDir(ctx, profile);
+    const modlistPath = join(profileDir, "modlist.txt");
     const existing = await readFile(modlistPath, "utf8").catch(() => "");
     const newLine = `+${modName}`;
     const lines = existing.length === 0 ? [] : existing.split(/\r?\n/).filter((line) => line.length > 0);
@@ -227,7 +397,26 @@ const handler: PlanApplyHandler = {
       await atomicWriteText(modlistPath, updated);
     }
 
-    // 5. Invalidate sidecar World cache so subsequent asset reads see the new mod.
+    // 5. BUG-14 BUG-E: register fresh-install plugins in plugins.txt.
+    // Before this fix, every mo2_install completed "successfully" but
+    // the mod's plugins stayed inactive — the agent had to do a separate
+    // enumeration + N×toggle_plugin calls to actually activate them.
+    const pluginsTxtPath = join(profileDir, "plugins.txt");
+    const pluginsRegistered = await _registerPluginsInPluginsTxt(finalDestPath, pluginsTxtPath);
+
+    // 6. If live broker is up, ask MO2 to re-scan so the freshly-written
+    // plugins.txt rows become active in MO2's in-memory plugin list.
+    // Best-effort: ignore failures (the file write already took, and
+    // MO2 will see it on next user-driven refresh either way).
+    if (pluginsRegistered.length > 0 && bound.pipeClient) {
+      try {
+        await bound.pipeClient.call("organizer.refresh", { save_changes: false });
+      } catch {
+        // swallowed: see comment above
+      }
+    }
+
+    // 7. Invalidate sidecar World cache so subsequent asset reads see the new mod.
     await invalidateWorld(ctx, [profile]);
 
     return {
@@ -235,6 +424,7 @@ const handler: PlanApplyHandler = {
       dest_path: finalDestPath,
       fomod_used: useFomodChoices,
       installation_file: basename(archivePath),
+      plugins_registered: pluginsRegistered,
     };
   },
 };

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/src/tools/mo2-send-mod-to.ts
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/src/tools/mo2-send-mod-to.ts
@@ -53,9 +53,31 @@ async function _computeTargetPriority(
   const p = await readProfile(join(bound.config.mo2Root, "profiles", profile));
   const nonSep = p.mods.filter((m) => !m.isSeparator);
   const mode = args.target_mode as string;
+
+  // BUG-14 BUG-B fix (issue #14): the broker's `mods.set_priority`
+  // validates `priority <= len(non_separator_mods)` and then calls
+  // mobase.IModList.setPriority in non-separator priority space.
+  // `profile-reader.ts` assigns priorities from the FULL modlist.txt
+  // line count (which includes separators). So a value computed in
+  // full-priority space (e.g. `sep.priority + 1`) overshoots the
+  // broker validator whenever separators occupy upper slots — the
+  // real-world BB84 case: separator at full priority 391 with 30
+  // separators above produced plan→392, broker rejected with
+  // "priority 392 out of [0..375]".
+  //
+  // Convert via `nonSepRank(fullPrio)` = count of non-separator mods
+  // strictly below `fullPrio` in full-priority space. That count is
+  // exactly the non-separator slot just above the given full-prio
+  // position. Clamp to [0, nonSep.length - 1] to stay within broker
+  // bounds.
+  const nonSepRank = (fullPrio: number): number =>
+    nonSep.filter((m) => m.priority < fullPrio).length;
+  const maxNonSepPri = Math.max(0, nonSep.length - 1);
+  const clamp = (v: number): number => Math.max(0, Math.min(v, maxNonSepPri));
+
   switch (mode) {
     case "top":
-      return Math.max(nonSep.length - 1, 0);
+      return maxNonSepPri;
     case "bottom":
       return 0;
     case "priority":
@@ -63,7 +85,7 @@ async function _computeTargetPriority(
     case "above_separator": {
       const sep = p.mods.find((m) => m.isSeparator && m.name === args.target_separator);
       if (!sep) throw new Error(`separator_not_found: ${args.target_separator}`);
-      return sep.priority + 1;
+      return clamp(nonSepRank(sep.priority));
     }
     case "above_first_conflict":
     case "below_last_conflict": {
@@ -81,10 +103,15 @@ async function _computeTargetPriority(
       if (conflictMods.length === 0) {
         throw new Error("no_conflicts_found");
       }
-      const conflictPriorities = conflictMods
-        .map((n) => p.mods.find((m) => m.name === n)?.priority ?? 0);
-      if (mode === "above_first_conflict") return Math.max(...conflictPriorities) + 1;
-      return Math.max(Math.min(...conflictPriorities) - 1, 0);
+      const conflictRanks = conflictMods
+        .map((n) => p.mods.find((m) => m.name === n))
+        .filter((m): m is (typeof p.mods)[number] => m !== undefined && !m.isSeparator)
+        .map((m) => nonSepRank(m.priority));
+      if (conflictRanks.length === 0) {
+        throw new Error("no_conflicts_found");
+      }
+      if (mode === "above_first_conflict") return clamp(Math.max(...conflictRanks) + 1);
+      return clamp(Math.min(...conflictRanks) - 1);
     }
     default:
       throw new Error(`unknown_mode: ${mode}`);

--- a/tools/mo2-mcp-sidecar/src/mo2_mcp_sidecar/archive.py
+++ b/tools/mo2-mcp-sidecar/src/mo2_mcp_sidecar/archive.py
@@ -2,10 +2,19 @@
 
 Used by mo2_install's plan step to stage archive contents into
 <MO2_Root>/.mo2-mcp/staging/<install_id>/ before computing conflict preview.
+
+BUG-14 BUG-C fix (issue #14): py7zr's ``SevenZipFile`` only understands the
+7z container format and raises ``Bad7zFile: not a 7z file`` on .rar input.
+The .rar branch shells out to ``7z.exe`` (the 7-Zip CLI), which handles
+RAR natively. Nexus carries a long tail of .rar uploads (older mods, e.g.
+Starfield Extended - Craftable Quality v4.1 #5721 ships as .rar) and the
+prior code path made ``mo2_install`` unusable for them.
 """
 from __future__ import annotations
 
 import os
+import shutil
+import subprocess
 import zipfile
 from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
 from typing import Any
@@ -17,6 +26,115 @@ try:
     _PY7ZR_AVAILABLE = True
 except ImportError:
     _PY7ZR_AVAILABLE = False
+
+
+# Well-known Windows 7-Zip install paths used as a fallback when neither
+# BGS_SEVENZIP_PATH nor a PATH lookup turns up the binary.
+_WIN_7Z_FALLBACK_PATHS = (
+    r"C:\Program Files\7-Zip\7z.exe",
+    r"C:\Program Files (x86)\7-Zip\7z.exe",
+)
+
+
+def _find_7z_exe() -> str | None:
+    """Locate a usable 7-Zip CLI for shell-out extraction.
+
+    Precedence:
+      1. ``$BGS_SEVENZIP_PATH`` (explicit override; agent installs / CI)
+      2. ``shutil.which("7z")`` / ``shutil.which("7z.exe")`` (PATH lookup)
+      3. Well-known Windows install paths
+
+    Returns the resolved binary path or ``None`` if 7-Zip is not findable.
+    Callers raise an actionable error pointing at the install URL.
+    """
+    env_path = os.environ.get("BGS_SEVENZIP_PATH")
+    if env_path and Path(env_path).is_file():
+        return env_path
+    for name in ("7z", "7z.exe"):
+        which = shutil.which(name)
+        if which:
+            return which
+    for candidate in _WIN_7Z_FALLBACK_PATHS:
+        if Path(candidate).is_file():
+            return candidate
+    return None
+
+
+def _list_via_7z_exe(seven_z: str, archive_path: Path) -> list[str]:
+    """Enumerate archive members via ``7z l -slt`` so they can be pre-validated.
+
+    Defense-in-depth: even though 7-Zip itself sanitizes against absolute
+    paths and ``..`` traversal in modern versions, we still pre-list and
+    run each member through :func:`_validate_safe_member` so the contract
+    matches the .zip / .7z branches above.
+    """
+    result = subprocess.run(
+        [seven_z, "l", "-slt", str(archive_path)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip() or "(no stderr)"
+        raise RuntimeError(f"7z_list_failed: exit {result.returncode}: {stderr}")
+    members: list[str] = []
+    for line in result.stdout.splitlines():
+        if line.startswith("Path = "):
+            members.append(line[len("Path = "):])
+    # First "Path = " in -slt is the archive itself; skip.
+    return members[1:] if members else []
+
+
+def _extract_via_7z_exe(archive_path: Path, dest: Path) -> list[str]:
+    """Extract any archive 7-Zip understands (used for .rar here).
+
+    Validates each member name via :func:`_validate_safe_member` before
+    invoking the CLI. After extraction walks ``dest`` to enumerate the
+    actually-extracted files (7-Zip emits no JSON listing on stdout, so
+    a directory walk is the most portable enumeration path and keeps
+    behavior parallel to the .zip / .7z branches).
+    """
+    seven_z = _find_7z_exe()
+    if seven_z is None:
+        raise RuntimeError(
+            "7z_exe_not_found: set BGS_SEVENZIP_PATH or install 7-Zip from "
+            "https://www.7-zip.org/ to enable .rar extraction"
+        )
+
+    members = _list_via_7z_exe(seven_z, archive_path)
+    for member in members:
+        if member:
+            _validate_safe_member(member, dest)
+
+    try:
+        result = subprocess.run(
+            [
+                seven_z, "x",
+                str(archive_path),
+                f"-o{dest}",
+                "-y",
+                "-bso0",
+                "-bsp0",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("7z_exe_timeout: archive extraction exceeded 300s") from exc
+
+    if result.returncode != 0:
+        # 7z exit codes: 0=ok, 1=warning, 2=fatal, 7=cmdline, 8=memory, 255=user abort
+        stderr = (result.stderr or "").strip() or "(no stderr)"
+        raise RuntimeError(f"7z_exe_failed: exit {result.returncode}: {stderr}")
+
+    extracted: list[str] = []
+    for path in dest.rglob("*"):
+        if path.is_file():
+            extracted.append(path.relative_to(dest).as_posix())
+    return extracted
 
 
 def _is_absolute_member(member_name: str) -> bool:
@@ -110,14 +228,21 @@ def archive_extract_all(params: dict[str, Any]) -> dict[str, Any]:
                 _validate_safe_member(name, dest)
             zf.extractall(dest)
         fmt = "zip"
-    elif suffix in (".7z", ".rar"):
+    elif suffix == ".7z":
         if not _PY7ZR_AVAILABLE:
             raise RuntimeError("py7zr_not_available")
         with py7zr.SevenZipFile(archive_path) as z:
             extracted = _safe_7z_targets(list(z.list()), dest)
             if extracted:
                 z.extract(path=str(dest), targets=extracted)
-        fmt = "7z" if suffix == ".7z" else "rar"
+        fmt = "7z"
+    elif suffix == ".rar":
+        # BUG-14 BUG-C (issue #14): py7zr does NOT support RAR; routing it
+        # through SevenZipFile produced ``Bad7zFile: not a 7z file`` and
+        # made every .rar Nexus archive uninstallable via mo2_install.
+        # Shell out to 7z.exe which understands the format natively.
+        extracted = _extract_via_7z_exe(archive_path, dest)
+        fmt = "rar"
     else:
         raise RuntimeError(f"unsupported_archive_format: {suffix}")
 

--- a/tools/mo2-mcp-sidecar/tests/test_archive.py
+++ b/tools/mo2-mcp-sidecar/tests/test_archive.py
@@ -83,3 +83,106 @@ def test_extract_all_7z_format(tmp_path):
 
     assert result["format"] == "7z"
     assert (dest / "inside.txt").read_text() == "inside-7z"
+
+
+# BUG-14 BUG-C (issue #14): .rar must NOT route through py7zr (Bad7zFile
+# error) and must succeed when 7z.exe is available on PATH / fallback paths
+# / via BGS_SEVENZIP_PATH override.
+class TestRarSupport:
+    def test_find_7z_exe_honors_env_override(self, tmp_path, monkeypatch):
+        fake = tmp_path / "fake-7z.exe"
+        fake.write_text("not really a binary")  # only needs to exist
+        monkeypatch.setenv("BGS_SEVENZIP_PATH", str(fake))
+        assert archive._find_7z_exe() == str(fake)
+
+    def test_find_7z_exe_ignores_nonexistent_override(self, monkeypatch):
+        monkeypatch.setenv("BGS_SEVENZIP_PATH", "/path/that/does/not/exist/7z.exe")
+        # Should fall through to PATH lookup / fallback paths; we don't
+        # assert a specific result here because it depends on the host's
+        # 7-Zip install. We just assert it doesn't raise.
+        result = archive._find_7z_exe()
+        assert result is None or Path(result).is_file()
+
+    def test_extract_rar_raises_clear_error_when_7z_exe_missing(self, tmp_path, monkeypatch):
+        # Force _find_7z_exe to return None.
+        monkeypatch.setattr(archive, "_find_7z_exe", lambda: None)
+        # Create a fake .rar file (we never actually try to read it because
+        # _find_7z_exe is mocked to return None before the shell-out).
+        rar = tmp_path / "fake.rar"
+        rar.write_bytes(b"Rar!\x1a\x07\x00")  # RAR magic, content irrelevant
+        with pytest.raises(RuntimeError, match="7z_exe_not_found"):
+            archive.archive_extract_all({
+                "archive_path": str(rar),
+                "dest": str(tmp_path / "out"),
+            })
+
+    def test_extract_rar_routes_through_7z_exe_not_py7zr(self, tmp_path, monkeypatch):
+        """Asserts the .rar branch invokes 7z.exe and bypasses py7zr.
+
+        Without the fix, .rar fell into the (.7z, .rar) branch and py7zr
+        raised Bad7zFile. Mock _find_7z_exe + subprocess.run + the directory
+        walk to prove the routing without requiring a real RAR fixture.
+        """
+        seven_z_path = "/fake/7z.exe"
+        monkeypatch.setattr(archive, "_find_7z_exe", lambda: seven_z_path)
+
+        calls: list[tuple] = []
+
+        def _fake_list(seven_z, archive_path):
+            calls.append(("list", seven_z, str(archive_path)))
+            return ["only.txt"]
+
+        monkeypatch.setattr(archive, "_list_via_7z_exe", _fake_list)
+
+        class _FakeResult:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+
+        def _fake_run(cmd, **kwargs):
+            calls.append(("run", tuple(cmd)))
+            # Simulate extraction by creating the destination file. The
+            # -o<dest> argument is the only one starting with "-o".
+            dest_arg = next(a for a in cmd if a.startswith("-o"))
+            dest = Path(dest_arg[2:])
+            dest.mkdir(parents=True, exist_ok=True)
+            (dest / "only.txt").write_text("extracted from rar")
+            return _FakeResult()
+
+        monkeypatch.setattr(archive.subprocess, "run", _fake_run)
+
+        rar = tmp_path / "fake.rar"
+        rar.write_bytes(b"Rar!\x1a\x07\x00")
+        dest = tmp_path / "out"
+        result = archive.archive_extract_all({
+            "archive_path": str(rar),
+            "dest": str(dest),
+        })
+
+        assert result["format"] == "rar"
+        assert "only.txt" in result["files"]
+        assert (dest / "only.txt").read_text() == "extracted from rar"
+        # Prove the 7z.exe path was actually taken.
+        assert any(c[0] == "list" for c in calls), f"list step missing: {calls}"
+        assert any(c[0] == "run" and seven_z_path in c[1] for c in calls), f"7z.exe invocation missing: {calls}"
+
+    def test_extract_rar_propagates_7z_exit_code(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(archive, "_find_7z_exe", lambda: "/fake/7z.exe")
+        monkeypatch.setattr(archive, "_list_via_7z_exe", lambda _s, _a: [])
+
+        class _FakeResult:
+            returncode = 2  # 7z fatal exit
+            stderr = "Cannot open the file as archive"
+            stdout = ""
+
+        def _fake_run(cmd, **kwargs):
+            return _FakeResult()
+
+        monkeypatch.setattr(archive.subprocess, "run", _fake_run)
+        rar = tmp_path / "bad.rar"
+        rar.write_bytes(b"Rar!\x1a\x07\x00")
+        with pytest.raises(RuntimeError, match="7z_exe_failed: exit 2"):
+            archive.archive_extract_all({
+                "archive_path": str(rar),
+                "dest": str(tmp_path / "out"),
+            })

--- a/tools/mo2-mcp/src/pipe-client.ts
+++ b/tools/mo2-mcp/src/pipe-client.ts
@@ -112,6 +112,19 @@ export class PipeClient {
     if (!this.pipeName) {
       throw new Error("pipe not discovered (call discoverAndConnect first)");
     }
+    // BUG-14 BUG-A (issue #14): lazy stale-pipe detection. The cached
+    // pipeName embeds the MO2 PID at the time of discoverAndConnect.
+    // If MO2 has been restarted since (new PID -> new broker pipe), this
+    // cached pipeName is dead and every T3 dispatch fails with
+    // `ENOENT \\.\pipe\mo2-control-plane-<oldPID>` even though MO2 is
+    // alive at a new PID. Re-read endpoint.json (fast: <1ms local file
+    // read) before each call; if the published endpoint differs from
+    // the cached pipeName, transparently auto-rebind. Without this,
+    // mo2_session reports `pipeConnected: true` (cached), but every
+    // mutating call silently routes to the dead pipe.
+    if (this.mo2Root) {
+      await this._maybeRefreshStaleEndpoint();
+    }
     const startedAt = Date.now();
     try {
       return await this._rawCall(method, payload, timeoutMs);
@@ -119,6 +132,48 @@ export class PipeClient {
       // No mo2Root means we can't drive the enrichment probes; rethrow raw.
       if (!this.mo2Root) throw err;
       throw await enrichBrokerError(err, method, this.mo2Root, startedAt);
+    }
+  }
+
+  /**
+   * Re-read endpoint.json and update the cached pipeName if it has changed.
+   *
+   * Used by `call()` to recover transparently when MO2 has been restarted
+   * since the original `discoverAndConnect`. We deliberately do NOT re-run
+   * the full discoverAndConnect cycle here:
+   *   - the broker publishes the new endpoint.json on every startup, so a
+   *     simple file read is enough to learn the new pipename;
+   *   - the full ping cycle would block every T3 dispatch in the steady-state
+   *     "pipe is still healthy" path, which is the overwhelming majority of
+   *     calls.
+   *
+   * If `endpoint.json` cannot be read (MO2 closed, plugin removed, IO
+   * race), this method silently returns; the subsequent `_rawCall` will
+   * fail normally and L1/L2 enrichment kicks in. This keeps the stale-pipe
+   * recovery best-effort and never adds a new failure mode.
+   */
+  async _maybeRefreshStaleEndpoint(): Promise<void> {
+    if (!this.mo2Root || !this.pipeName) return;
+    const endpointPath = join(
+      this.mo2Root,
+      "plugins",
+      "Mo2AgentControl",
+      "bootstrap",
+      "runtime",
+      "endpoint.json",
+    );
+    let endpoint: EndpointFile;
+    try {
+      endpoint = await readEndpoint(endpointPath, this.mo2Root);
+    } catch {
+      return;
+    }
+    const currentPipeName = pipeNameOnly(endpoint.endpoint);
+    if (currentPipeName && currentPipeName !== this.pipeName) {
+      process.stderr.write(
+        `[mo2-mcp] pipe endpoint changed (${this.pipeName} -> ${currentPipeName}); auto-rebinding\n`,
+      );
+      this.pipeName = currentPipeName;
     }
   }
 

--- a/tools/mo2-mcp/src/plan-apply.ts
+++ b/tools/mo2-mcp/src/plan-apply.ts
@@ -91,9 +91,19 @@ export class PlanCache {
  * Handler that an individual T2/T3 tool implements.
  * - buildPlan: compute diff + affected files + lease targets
  * - applyMutation: execute the mutation given the validated plan
+ * - acquirePlanLock?: opt out of plan-time filesystem lease locking
+ *   (default true). When false, runPlanMode records the lease fingerprint
+ *   without acquiring a filesystem lock; runApplyMode acquires the lock
+ *   briefly at apply time, verifies the fingerprint, mutates, releases.
+ *   Use for tools whose plan phase is pure read and whose lease targets
+ *   are shared write surfaces (multiple plans for distinct mods that all
+ *   land in the same profile's modlist.txt / plugins.txt). BUG-14 BUG-F
+ *   (issue #14): mo2_install opts in so parallel plans for distinct
+ *   mod_names don't block each other.
  */
 export interface PlanApplyHandler {
   toolName: string;
+  acquirePlanLock?: boolean;
   buildPlan(
     args: Record<string, unknown>,
     ctx: ToolContext,
@@ -168,33 +178,49 @@ export async function runPlanMode(
   const planId = randomUUID();
   const expiresAt = Date.now() + LEASE_LOCK_TTL_MS;
   const createdAt = new Date().toISOString();
-  const lock = await acquireLeasesForTargets(requireBoundContext(ctx).config.mo2Root, built.targets, {
-    plan_id: planId,
-    mcp_pid: process.pid,
-    mcp_session_id: ctx.sessionId,
-    lease_token: lease.token,
-    tool_name: handler.toolName,
-    created_at: createdAt,
-    expires_at: new Date(expiresAt).toISOString(),
-  });
-  if (!lock.acquired) {
-    const holders = lock.holders.map((holder) => ({
-      tool: holder.tool_name,
-      tool_name: holder.tool_name,
-      mcp_pid: holder.mcp_pid,
-      created_at: holder.created_at,
-    }));
-    const firstHolder = holders[0];
-    return {
-      ok: false,
-      error: {
-        code: "lease_held",
-        message: `Target is already locked by ${firstHolder.tool_name} in MCP process ${firstHolder.mcp_pid}`,
-        holder: firstHolder,
-        holders,
+
+  // BUG-14 BUG-F (issue #14): handlers may opt to defer lease lock
+  // acquisition to apply time so plan-only operations can run
+  // concurrently against shared write surfaces. When deferred, plan
+  // returns without acquiring any filesystem lock; runApplyMode picks
+  // it up at apply boundary.
+  const lockAtPlan = handler.acquirePlanLock !== false;
+  let leaseLockTargetHashes: string[] = [];
+  if (lockAtPlan) {
+    const lock = await acquireLeasesForTargets(
+      requireBoundContext(ctx).config.mo2Root,
+      built.targets,
+      {
+        plan_id: planId,
+        mcp_pid: process.pid,
+        mcp_session_id: ctx.sessionId,
+        lease_token: lease.token,
+        tool_name: handler.toolName,
+        created_at: createdAt,
+        expires_at: new Date(expiresAt).toISOString(),
       },
-    };
+    );
+    if (!lock.acquired) {
+      const holders = lock.holders.map((holder) => ({
+        tool: holder.tool_name,
+        tool_name: holder.tool_name,
+        mcp_pid: holder.mcp_pid,
+        created_at: holder.created_at,
+      }));
+      const firstHolder = holders[0];
+      return {
+        ok: false,
+        error: {
+          code: "lease_held",
+          message: `Target is already locked by ${firstHolder.tool_name} in MCP process ${firstHolder.mcp_pid}`,
+          holder: firstHolder,
+          holders,
+        },
+      };
+    }
+    leaseLockTargetHashes = lock.targetHashes;
   }
+
   let rec: PlanRecord;
   try {
     rec = cache.store({
@@ -205,10 +231,16 @@ export async function runPlanMode(
       diff: built.diff,
       affectedFiles: built.affectedFiles,
       lease,
-      leaseLockTargetHashes: lock.targetHashes,
+      leaseLockTargetHashes,
     });
   } catch (error) {
-    await releaseLeaseLocks(requireBoundContext(ctx).config.mo2Root, lock.targetHashes, planId);
+    if (lockAtPlan) {
+      await releaseLeaseLocks(
+        requireBoundContext(ctx).config.mo2Root,
+        leaseLockTargetHashes,
+        planId,
+      );
+    }
     throw error;
   }
   return {
@@ -262,6 +294,51 @@ export async function runApplyMode(
       },
     };
   }
+
+  // BUG-14 BUG-F (issue #14): when the handler opted out of plan-time
+  // locking, acquire the filesystem lock here at the apply boundary.
+  // Concurrent applies serialize naturally; the lease verification
+  // immediately below catches any drift that happened between this
+  // plan's generation and the moment the lock was acquired.
+  if (handler.acquirePlanLock === false) {
+    const lock = await acquireLeasesForTargets(
+      requireBoundContext(ctx).config.mo2Root,
+      rec.lease.components.map((component) => ({
+        path: component.path,
+        kind: component.kind,
+      })),
+      {
+        plan_id: rec.planId,
+        mcp_pid: process.pid,
+        mcp_session_id: ctx.sessionId,
+        lease_token: rec.lease.token,
+        tool_name: handler.toolName,
+        created_at: new Date().toISOString(),
+        expires_at: new Date(rec.expiresAt).toISOString(),
+      },
+    );
+    if (!lock.acquired) {
+      const holders = lock.holders.map((holder) => ({
+        tool: holder.tool_name,
+        tool_name: holder.tool_name,
+        mcp_pid: holder.mcp_pid,
+        created_at: holder.created_at,
+      }));
+      const firstHolder = holders[0];
+      return {
+        ok: false,
+        error: {
+          code: "lease_held",
+          message: `Target is already locked by ${firstHolder.tool_name} in MCP process ${firstHolder.mcp_pid}`,
+          // ApplyResult's error shape is generic; pass holder details in
+          // a side-channel-compatible field so callers can introspect.
+          drift: { holder: firstHolder, holders },
+        },
+      };
+    }
+    rec.leaseLockTargetHashes = lock.targetHashes;
+  }
+
   const v = await verifyLease(rec.lease);
   if (!v.valid) {
     await releasePlanLockBestEffort(ctx, rec);

--- a/tools/mo2-mcp/src/tools/mo2-install.ts
+++ b/tools/mo2-mcp/src/tools/mo2-install.ts
@@ -20,7 +20,7 @@
 import { z } from "zod";
 import { readFile, mkdir, rename, cp, readdir, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { join, basename } from "node:path";
+import { join, basename, extname, dirname } from "node:path";
 import { randomUUID } from "node:crypto";
 import { registerTool } from "../tool-registry.js";
 import { routeToPlanApply, type PlanApplyHandler } from "../plan-apply.js";
@@ -66,6 +66,155 @@ async function _copyDirectoryContents(sourceDir: string, destDir: string): Promi
   for (const entry of entries) {
     await cp(join(sourceDir, entry.name), join(destDir, entry.name), { recursive: true });
   }
+}
+
+// BUG-14 BUG-D (issue #14): BGS mod archives commonly wrap content in a
+// top-level `Data/` directory (per BGS convention), or a `<modname>/`
+// wrapper, or both. MO2's GUI installer flattens these so the plugin
+// lands at `mods/<modname>/<plugin>.esm`, not at
+// `mods/<modname>/Data/<plugin>.esm`. Without flattening, MO2's VFS
+// projects the file as `<game>/Data/Data/<plugin>.esm` and the engine
+// silently cannot find it.
+//
+// Heuristic, in priority order:
+//  1. Plugin file (.esm/.esp/.esl) at this level → this is the mod root.
+//  2. Known BGS asset directory (meshes, textures, scripts, fomod, sfse,
+//     f4se, skse, etc.) at this level → mod root (asset-only mods are
+//     valid; no plugin required).
+//  3. Single subdirectory and no hits at this level → recurse into it
+//     (handles the common Data/ and ModName/Data/ wrappers).
+//  4. Anything else (multiple subdirs without plugins or asset markers)
+//     → ambiguous, leave layout as-is.
+//
+// Depth is capped at 4 to avoid pathological extracts. The original
+// staging dir itself is never removed (it's the destination).
+const _PLUGIN_EXTS = new Set([".esm", ".esp", ".esl"]);
+const _BGS_ASSET_DIRS = new Set([
+  // BGS-standard
+  "meshes",
+  "textures",
+  "sound",
+  "music",
+  "materials",
+  "scripts",
+  "interface",
+  "seq",
+  "video",
+  "lodsettings",
+  "shadersfx",
+  "strings",
+  // Installer & xSE
+  "fomod",
+  "f4se",
+  "skse",
+  "skse64",
+  "sfse",
+  "obse",
+  "fose",
+  "nvse",
+  // Misc engine roots that show up in real archives
+  "platform",
+  "menus",
+]);
+
+async function _findBgsModRoot(dir: string, depth: number, maxDepth = 4): Promise<string | null> {
+  if (depth > maxDepth) return null;
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    if (entry.isFile() && _PLUGIN_EXTS.has(extname(entry.name).toLowerCase())) {
+      return dir;
+    }
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory() && _BGS_ASSET_DIRS.has(entry.name.toLowerCase())) {
+      return dir;
+    }
+  }
+  const subdirs = entries.filter((e) => e.isDirectory());
+  if (subdirs.length === 1) {
+    return _findBgsModRoot(join(dir, subdirs[0].name), depth + 1, maxDepth);
+  }
+  return null;
+}
+
+async function _flattenBgsArchive(stagingDir: string): Promise<{ flattened: boolean; from?: string }> {
+  const root = await _findBgsModRoot(stagingDir, 0);
+  if (!root || root === stagingDir) return { flattened: false };
+  // Move root's entries up to stagingDir, then clean the now-empty
+  // intermediate directories. Two-pass: first read, then rename.
+  const rootEntries = await readdir(root);
+  for (const name of rootEntries) {
+    await rename(join(root, name), join(stagingDir, name));
+  }
+  // Walk the chain from `root` back up to stagingDir's child and rm each
+  // emptied dir. dirname() loop stops once we reach stagingDir.
+  let cleanup: string | null = root;
+  while (cleanup && cleanup !== stagingDir) {
+    try {
+      await rm(cleanup, { recursive: true, force: true });
+    } catch {
+      break;
+    }
+    const parent = dirname(cleanup);
+    if (parent === cleanup) break;
+    cleanup = parent === stagingDir ? null : parent;
+  }
+  return { flattened: true, from: root };
+}
+
+// BUG-14 BUG-E (issue #14): enumerate plugin files at the final mod root
+// and register them in the profile's plugins.txt. Without this, every
+// install completed "successfully" but the mod's plugins stayed inactive
+// — the agent had to do a separate enumeration + N×toggle_plugin calls
+// to actually activate them.
+//
+// Behavior matches MO2 GUI's "Install Mod from Archive": newly-installed
+// plugins land enabled (asterisk prefix in plugins.txt per FO4/SSE
+// convention). Existing entries (case-insensitive match) are preserved
+// — we never overwrite a disabled plugin's state.
+async function _registerPluginsInPluginsTxt(
+  modRoot: string,
+  pluginsTxtPath: string,
+): Promise<string[]> {
+  let modEntries: import("node:fs").Dirent[];
+  try {
+    modEntries = await readdir(modRoot, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const newPlugins = modEntries
+    .filter((e) => e.isFile() && _PLUGIN_EXTS.has(extname(e.name).toLowerCase()))
+    .map((e) => e.name)
+    .sort();
+  if (newPlugins.length === 0) return [];
+
+  const existingTxt = await readFile(pluginsTxtPath, "utf8").catch(() => "");
+  const existingLower = new Set(
+    existingTxt
+      .split(/\r?\n/)
+      .filter((line) => line.length > 0 && !line.startsWith("#"))
+      .map((line) => line.replace(/^\*/, "").trim().toLowerCase()),
+  );
+
+  const linesToAdd: string[] = [];
+  const registered: string[] = [];
+  for (const plugin of newPlugins) {
+    if (!existingLower.has(plugin.toLowerCase())) {
+      linesToAdd.push(`*${plugin}`);
+      registered.push(plugin);
+    }
+  }
+  if (linesToAdd.length === 0) return [];
+
+  const sep = existingTxt.length === 0 || existingTxt.endsWith("\n") ? "" : "\n";
+  const newTxt = `${existingTxt}${sep}${linesToAdd.join("\n")}\n`;
+  await atomicWriteText(pluginsTxtPath, newTxt);
+  return registered;
 }
 
 // FOMOD detection + choices-shape helpers were extracted into
@@ -117,11 +266,19 @@ const handler: PlanApplyHandler = {
 
     const profileDir = resolveProfileDir(ctx, profile);
     const modlistPath = join(profileDir, "modlist.txt");
+    // BUG-14 BUG-E (issue #14): track plugins.txt as an affected file so
+    // the snapshot taken at apply time captures its pre-write state and
+    // rollback can restore it. Lease target as well so concurrent installs
+    // detect plugins.txt drift between plan and apply.
+    const pluginsTxtPath = join(profileDir, "plugins.txt");
 
     return {
       diff: `Install ${modName} (FOMOD=${isFomod}, target_priority=${String(args.target_priority)})`,
-      affectedFiles: [destPath, modlistPath],
-      targets: [{ path: modlistPath, kind: "text-file" }],
+      affectedFiles: [destPath, modlistPath, pluginsTxtPath],
+      targets: [
+        { path: modlistPath, kind: "text-file" },
+        { path: pluginsTxtPath, kind: "text-file" },
+      ],
     };
   },
 
@@ -157,6 +314,12 @@ const handler: PlanApplyHandler = {
         archive_path: archivePath,
         dest: stagingDir,
       });
+      // BUG-14 BUG-D: flatten common BGS archive wrapper patterns
+      // (Data/, ModName/, ModName/Data/) so the plugin and assets land
+      // at the mod folder root, not inside a Data/ subdir that MO2's
+      // VFS would double-prefix. FOMOD-staged installs already map
+      // source→destination explicitly so they don't need this pass.
+      await _flattenBgsArchive(stagingDir);
     }
 
     // 2. Live broker createMod creates the destination directory itself; copy
@@ -216,7 +379,8 @@ const handler: PlanApplyHandler = {
     await atomicWriteText(join(finalDestPath, "meta.ini"), meta + "\n");
 
     // 4. Register in modlist.txt.
-    const modlistPath = join(resolveProfileDir(ctx, profile), "modlist.txt");
+    const profileDir = resolveProfileDir(ctx, profile);
+    const modlistPath = join(profileDir, "modlist.txt");
     const existing = await readFile(modlistPath, "utf8").catch(() => "");
     const newLine = `+${modName}`;
     const lines = existing.length === 0 ? [] : existing.split(/\r?\n/).filter((line) => line.length > 0);
@@ -227,7 +391,26 @@ const handler: PlanApplyHandler = {
       await atomicWriteText(modlistPath, updated);
     }
 
-    // 5. Invalidate sidecar World cache so subsequent asset reads see the new mod.
+    // 5. BUG-14 BUG-E: register fresh-install plugins in plugins.txt.
+    // Before this fix, every mo2_install completed "successfully" but
+    // the mod's plugins stayed inactive — the agent had to do a separate
+    // enumeration + N×toggle_plugin calls to actually activate them.
+    const pluginsTxtPath = join(profileDir, "plugins.txt");
+    const pluginsRegistered = await _registerPluginsInPluginsTxt(finalDestPath, pluginsTxtPath);
+
+    // 6. If live broker is up, ask MO2 to re-scan so the freshly-written
+    // plugins.txt rows become active in MO2's in-memory plugin list.
+    // Best-effort: ignore failures (the file write already took, and
+    // MO2 will see it on next user-driven refresh either way).
+    if (pluginsRegistered.length > 0 && bound.pipeClient) {
+      try {
+        await bound.pipeClient.call("organizer.refresh", { save_changes: false });
+      } catch {
+        // swallowed: see comment above
+      }
+    }
+
+    // 7. Invalidate sidecar World cache so subsequent asset reads see the new mod.
     await invalidateWorld(ctx, [profile]);
 
     return {
@@ -235,6 +418,7 @@ const handler: PlanApplyHandler = {
       dest_path: finalDestPath,
       fomod_used: useFomodChoices,
       installation_file: basename(archivePath),
+      plugins_registered: pluginsRegistered,
     };
   },
 };

--- a/tools/mo2-mcp/src/tools/mo2-install.ts
+++ b/tools/mo2-mcp/src/tools/mo2-install.ts
@@ -225,6 +225,12 @@ async function _registerPluginsInPluginsTxt(
 
 const handler: PlanApplyHandler = {
   toolName: "mo2_install",
+  // BUG-14 BUG-F (issue #14): defer lease lock to apply time so parallel
+  // plans for distinct mod_names don't contend on shared modlist.txt /
+  // plugins.txt lease targets. The fingerprint stored at plan time still
+  // catches inter-plan drift; apply-time lock acquisition serializes the
+  // actual mutations.
+  acquirePlanLock: false,
   async buildPlan(args, ctx) {
     const bound = requireBoundContext(ctx);
     if (!bound.sidecar) {

--- a/tools/mo2-mcp/src/tools/mo2-send-mod-to.ts
+++ b/tools/mo2-mcp/src/tools/mo2-send-mod-to.ts
@@ -53,9 +53,31 @@ async function _computeTargetPriority(
   const p = await readProfile(join(bound.config.mo2Root, "profiles", profile));
   const nonSep = p.mods.filter((m) => !m.isSeparator);
   const mode = args.target_mode as string;
+
+  // BUG-14 BUG-B fix (issue #14): the broker's `mods.set_priority`
+  // validates `priority <= len(non_separator_mods)` and then calls
+  // mobase.IModList.setPriority in non-separator priority space.
+  // `profile-reader.ts` assigns priorities from the FULL modlist.txt
+  // line count (which includes separators). So a value computed in
+  // full-priority space (e.g. `sep.priority + 1`) overshoots the
+  // broker validator whenever separators occupy upper slots — the
+  // real-world BB84 case: separator at full priority 391 with 30
+  // separators above produced plan→392, broker rejected with
+  // "priority 392 out of [0..375]".
+  //
+  // Convert via `nonSepRank(fullPrio)` = count of non-separator mods
+  // strictly below `fullPrio` in full-priority space. That count is
+  // exactly the non-separator slot just above the given full-prio
+  // position. Clamp to [0, nonSep.length - 1] to stay within broker
+  // bounds.
+  const nonSepRank = (fullPrio: number): number =>
+    nonSep.filter((m) => m.priority < fullPrio).length;
+  const maxNonSepPri = Math.max(0, nonSep.length - 1);
+  const clamp = (v: number): number => Math.max(0, Math.min(v, maxNonSepPri));
+
   switch (mode) {
     case "top":
-      return Math.max(nonSep.length - 1, 0);
+      return maxNonSepPri;
     case "bottom":
       return 0;
     case "priority":
@@ -63,7 +85,7 @@ async function _computeTargetPriority(
     case "above_separator": {
       const sep = p.mods.find((m) => m.isSeparator && m.name === args.target_separator);
       if (!sep) throw new Error(`separator_not_found: ${args.target_separator}`);
-      return sep.priority + 1;
+      return clamp(nonSepRank(sep.priority));
     }
     case "above_first_conflict":
     case "below_last_conflict": {
@@ -81,10 +103,15 @@ async function _computeTargetPriority(
       if (conflictMods.length === 0) {
         throw new Error("no_conflicts_found");
       }
-      const conflictPriorities = conflictMods
-        .map((n) => p.mods.find((m) => m.name === n)?.priority ?? 0);
-      if (mode === "above_first_conflict") return Math.max(...conflictPriorities) + 1;
-      return Math.max(Math.min(...conflictPriorities) - 1, 0);
+      const conflictRanks = conflictMods
+        .map((n) => p.mods.find((m) => m.name === n))
+        .filter((m): m is (typeof p.mods)[number] => m !== undefined && !m.isSeparator)
+        .map((m) => nonSepRank(m.priority));
+      if (conflictRanks.length === 0) {
+        throw new Error("no_conflicts_found");
+      }
+      if (mode === "above_first_conflict") return clamp(Math.max(...conflictRanks) + 1);
+      return clamp(Math.min(...conflictRanks) - 1);
     }
     default:
       throw new Error(`unknown_mode: ${mode}`);

--- a/tools/mo2-mcp/tests/pipe-client.stale-endpoint.test.ts
+++ b/tools/mo2-mcp/tests/pipe-client.stale-endpoint.test.ts
@@ -1,0 +1,113 @@
+/**
+ * BUG-14 BUG-A (issue #14) — stale broker pipe after MO2 process restart.
+ *
+ * Reproduction shape from the issue:
+ *   1. Start MO2 (PID A). Broker publishes endpoint.json with pipe name
+ *      `mo2-control-plane-<A>`. PipeClient.discoverAndConnect caches it.
+ *   2. Close MO2. Reopen MO2 (PID B). Broker rewrites endpoint.json with
+ *      `mo2-control-plane-<B>`. Old pipe is gone.
+ *   3. Without rebinding, every PipeClient.call hits the cached old pipe,
+ *      fails with `ENOENT \\.\pipe\mo2-control-plane-<A>`.
+ *
+ * Fix: PipeClient.call() calls `_maybeRefreshStaleEndpoint()` before
+ * `_rawCall`. That method re-reads endpoint.json (cheap local file read);
+ * if the published pipe name differs from the cached `pipeName`, it
+ * transparently swaps in the new pipe name. The next `_rawCall` connects
+ * to the live broker instead of the dead one.
+ *
+ * These tests exercise the refresh helper directly using real fs (no node:fs
+ * module mock) so the substrate matches production behavior.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { PipeClient } from "../src/pipe-client.js";
+
+async function _writeEndpointJson(
+  mo2Root: string,
+  endpoint: string,
+  pid: number,
+): Promise<void> {
+  const dir = join(mo2Root, "plugins", "Mo2AgentControl", "bootstrap", "runtime");
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    join(dir, "endpoint.json"),
+    JSON.stringify({ endpoint, pid }),
+    "utf8",
+  );
+}
+
+describe("PipeClient._maybeRefreshStaleEndpoint (BUG-14 BUG-A)", () => {
+  let mo2Root: string;
+
+  beforeEach(async () => {
+    mo2Root = await mkdtemp(join(tmpdir(), "mo2-stale-pipe-"));
+  });
+
+  afterEach(async () => {
+    await rm(mo2Root, { recursive: true, force: true });
+  });
+
+  it("no-op when mo2Root is unset (one-off PipeClient usage)", async () => {
+    const client = new PipeClient();
+    // Force a cached pipeName without going through discoverAndConnect so we
+    // exercise the early-return branch.
+    (client as unknown as { pipeName: string }).pipeName = "some-pipe-name";
+    await (client as unknown as { _maybeRefreshStaleEndpoint(): Promise<void> })._maybeRefreshStaleEndpoint();
+    expect((client as unknown as { pipeName: string }).pipeName).toBe("some-pipe-name");
+  });
+
+  it("no-op when endpoint.json is absent (MO2 closed mid-call)", async () => {
+    const client = new PipeClient();
+    (client as unknown as { pipeName: string; mo2Root: string }).pipeName = "mo2-control-plane-89072";
+    (client as unknown as { pipeName: string; mo2Root: string }).mo2Root = mo2Root;
+    // No endpoint.json written.
+    await (client as unknown as { _maybeRefreshStaleEndpoint(): Promise<void> })._maybeRefreshStaleEndpoint();
+    // pipeName should remain unchanged; the next _rawCall will fail and
+    // L1/L2 enrichment will report the absent endpoint.
+    expect((client as unknown as { pipeName: string }).pipeName).toBe("mo2-control-plane-89072");
+  });
+
+  it("no-op when endpoint.json reports the SAME pipeName (MO2 still on original PID)", async () => {
+    await _writeEndpointJson(mo2Root, "mo2-control-plane-89072", 89072);
+    const client = new PipeClient();
+    (client as unknown as { pipeName: string; mo2Root: string }).pipeName = "mo2-control-plane-89072";
+    (client as unknown as { pipeName: string; mo2Root: string }).mo2Root = mo2Root;
+    await (client as unknown as { _maybeRefreshStaleEndpoint(): Promise<void> })._maybeRefreshStaleEndpoint();
+    expect((client as unknown as { pipeName: string }).pipeName).toBe("mo2-control-plane-89072");
+  });
+
+  it("auto-rebinds to the NEW pipeName when endpoint.json reports a different PID (MO2 was restarted)", async () => {
+    // Initial state: PipeClient cached pipe from the original MO2 launch.
+    const client = new PipeClient();
+    (client as unknown as { pipeName: string; mo2Root: string }).pipeName = "mo2-control-plane-89072";
+    (client as unknown as { pipeName: string; mo2Root: string }).mo2Root = mo2Root;
+
+    // MO2 restarted: broker rewrote endpoint.json with a new PID.
+    await _writeEndpointJson(mo2Root, "mo2-control-plane-44592", 44592);
+
+    await (client as unknown as { _maybeRefreshStaleEndpoint(): Promise<void> })._maybeRefreshStaleEndpoint();
+
+    // Cached pipeName now reflects the live broker. Next _rawCall will
+    // connect to the right pipe instead of `connect ENOENT
+    // \\.\pipe\mo2-control-plane-89072`.
+    expect((client as unknown as { pipeName: string }).pipeName).toBe("mo2-control-plane-44592");
+  });
+
+  it("strips the \\\\.\\pipe\\ prefix when the broker publishes a fully-qualified endpoint", async () => {
+    // Some endpoint.json writers may publish the full \\.\pipe\<name> form
+    // rather than the bare pipe name. The refresh must normalize through
+    // pipeNameOnly so the cached form stays consistent across both shapes.
+    await _writeEndpointJson(
+      mo2Root,
+      "\\\\.\\pipe\\mo2-control-plane-44592",
+      44592,
+    );
+    const client = new PipeClient();
+    (client as unknown as { pipeName: string; mo2Root: string }).pipeName = "mo2-control-plane-89072";
+    (client as unknown as { pipeName: string; mo2Root: string }).mo2Root = mo2Root;
+    await (client as unknown as { _maybeRefreshStaleEndpoint(): Promise<void> })._maybeRefreshStaleEndpoint();
+    expect((client as unknown as { pipeName: string }).pipeName).toBe("mo2-control-plane-44592");
+  });
+});

--- a/tools/mo2-mcp/tests/tools/mo2-install.test.ts
+++ b/tools/mo2-mcp/tests/tools/mo2-install.test.ts
@@ -649,6 +649,104 @@ describe("mo2_install", () => {
     });
   });
 
+  // BUG-14 BUG-F regression (issue #14): plan-only operations must be
+  // reentrant for distinct mod_name targets even though they share the
+  // same profile's modlist.txt / plugins.txt lease surface. Before the
+  // fix, two parallel plans for different mods triggered:
+  //   {ok:false, error:{code:"lease_held", message:"Target is already
+  //    locked by mo2_install in MCP process N"}}
+  // for the second+ plan. Now plan is reentrant; apply serializes.
+  describe("BUG-14 BUG-F: parallel plans for distinct mod_names are reentrant", () => {
+    it("two parallel plans for different mod_names both succeed", async () => {
+      const { ctx } = await _fixture((_root) => ({
+        call: async (method, params) => {
+          if (method === "fomod.parse_choices") throw new Error("not_a_fomod");
+          if (method === "archive.extract_all") {
+            const dest = (params as { dest: string }).dest;
+            await mkdir(dest, { recursive: true });
+            await writeFile(join(dest, "x.esp"), "fake", "utf8");
+            return { files: ["x.esp"], file_count: 1, dest, format: "zip" };
+          }
+          if (method === "world.invalidate") return { invalidated: true };
+          throw new Error(`unmocked: ${method}`);
+        },
+        isReady: () => true,
+        start: async () => {},
+        stop: async () => {},
+      }));
+
+      const tool = getTool("mo2_install")!;
+      const [plan1, plan2, plan3] = (await Promise.all([
+        tool.handler(
+          { mode: "plan", archive_path: "/tmp/a.zip", mod_name: "ParallelA" },
+          ctx,
+        ),
+        tool.handler(
+          { mode: "plan", archive_path: "/tmp/b.zip", mod_name: "ParallelB" },
+          ctx,
+        ),
+        tool.handler(
+          { mode: "plan", archive_path: "/tmp/c.zip", mod_name: "ParallelC" },
+          ctx,
+        ),
+      ])) as Array<{ ok: boolean; result?: unknown; error?: { code: string } }>;
+
+      // Pre-fix: plan2 and plan3 would have returned ok:false / lease_held.
+      expect(plan1.ok, `plan1 failed: ${JSON.stringify(plan1.error)}`).toBe(true);
+      expect(plan2.ok, `plan2 failed: ${JSON.stringify(plan2.error)}`).toBe(true);
+      expect(plan3.ok, `plan3 failed: ${JSON.stringify(plan3.error)}`).toBe(true);
+    });
+
+    it("apply still serializes via apply-time lock acquisition", async () => {
+      const { ctx } = await _fixture((_root) => ({
+        call: async (method, params) => {
+          if (method === "fomod.parse_choices") throw new Error("not_a_fomod");
+          if (method === "archive.extract_all") {
+            const dest = (params as { dest: string }).dest;
+            await mkdir(dest, { recursive: true });
+            await writeFile(join(dest, "ser.esp"), "fake", "utf8");
+            return { files: ["ser.esp"], file_count: 1, dest, format: "zip" };
+          }
+          if (method === "world.invalidate") return { invalidated: true };
+          throw new Error(`unmocked: ${method}`);
+        },
+        isReady: () => true,
+        start: async () => {},
+        stop: async () => {},
+      }));
+
+      const tool = getTool("mo2_install")!;
+      const plan1 = (await tool.handler(
+        { mode: "plan", archive_path: "/tmp/s1.zip", mod_name: "SerialA" },
+        ctx,
+      )) as { ok: boolean; result: { planId: string; lease_token: string } };
+      const plan2 = (await tool.handler(
+        { mode: "plan", archive_path: "/tmp/s2.zip", mod_name: "SerialB" },
+        ctx,
+      )) as { ok: boolean; result: { planId: string; lease_token: string } };
+      expect(plan1.ok).toBe(true);
+      expect(plan2.ok).toBe(true);
+
+      // First apply succeeds + mutates modlist.txt + plugins.txt.
+      const apply1 = (await tool.handler(
+        { mode: "apply", plan_id: plan1.result.planId, lease_token: plan1.result.lease_token },
+        ctx,
+      )) as { ok: boolean };
+      expect(apply1.ok).toBe(true);
+
+      // Second apply: plugins.txt + modlist.txt have drifted since plan2
+      // was generated. The apply-time lock acquires successfully (no other
+      // lock holder), but verifyLease detects the drift and returns
+      // lease_violation. Caller re-plans.
+      const apply2 = (await tool.handler(
+        { mode: "apply", plan_id: plan2.result.planId, lease_token: plan2.result.lease_token },
+        ctx,
+      )) as { ok: boolean; error?: { code: string } };
+      expect(apply2.ok).toBe(false);
+      expect(apply2.error?.code).toBe("lease_violation");
+    });
+  });
+
   it("apply offline path preserves the destPath clobber guard", async () => {
     const { root, ctx } = await _fixture((rootDir) => ({
       call: async (method, params) => {

--- a/tools/mo2-mcp/tests/tools/mo2-install.test.ts
+++ b/tools/mo2-mcp/tests/tools/mo2-install.test.ts
@@ -331,10 +331,14 @@ describe("mo2_install", () => {
     expect(modlist).toContain("+LiveMod");
     // BUG-9 fix (2026-06-17): buildPlan now also runs assertActiveProfile,
     // which adds an extra profile.active call before the apply guard.
+    // BUG-14 BUG-E fix (issue #14): apply now calls organizer.refresh
+    // after writing plugins.txt so MO2's in-memory plugin list re-reads
+    // the freshly-registered plugin.
     expect(brokerCalls.map((call) => call.method)).toEqual([
       "profile.active", // buildPlan guard
       "profile.active", // applyMutation guard
       "installation.create_mod_from_directory",
+      "organizer.refresh", // post-plugins.txt refresh (BUG-14 BUG-E)
     ]);
   });
 
@@ -371,6 +375,278 @@ describe("mo2_install", () => {
       ctx,
     )).rejects.toThrow(/cross_profile_live_mutation_blocked/);
     expect(existsSync(join(ctx.config.mo2Root, "mods", "BlockedLive"))).toBe(false);
+  });
+
+  // BUG-14 BUG-D + BUG-E regression (issue #14):
+  //   - BUG-D: archive wraps content in a top-level Data/ directory; install
+  //     must flatten so the plugin lands at mods/<name>/<plugin>.esm, not
+  //     mods/<name>/Data/<plugin>.esm (where the MO2 VFS double-prefixes it).
+  //   - BUG-E: install must register the discovered plugin in plugins.txt
+  //     so the agent doesn't have to do a separate N×toggle_plugin call to
+  //     activate it.
+  describe("BUG-14 BUG-D + BUG-E: install flattens Data/ wrapper and registers plugins", () => {
+    it("flattens Data/ wrapper produced by typical BGS archives", async () => {
+      const { root, ctx } = await _fixture((_root) => ({
+        call: async (method, params) => {
+          if (method === "fomod.parse_choices") throw new Error("not_a_fomod");
+          if (method === "archive.extract_all") {
+            // Real-world BB84 case: Astrogate v5.8 ships its ESMs inside
+            // a top-level Data/ directory. Simulate that exact layout.
+            const dest = (params as { dest: string }).dest;
+            await mkdir(join(dest, "Data"), { recursive: true });
+            await writeFile(join(dest, "Data", "Astrogate.esm"), "fake-esm", "utf8");
+            await writeFile(
+              join(dest, "Data", "AstrogateGravJumpMod.esm"),
+              "fake-esm-2",
+              "utf8",
+            );
+            await writeFile(
+              join(dest, "Data", "Astrogate - Main.ba2"),
+              "fake-ba2",
+              "utf8",
+            );
+            return { files: ["Data/Astrogate.esm", "Data/AstrogateGravJumpMod.esm", "Data/Astrogate - Main.ba2"], file_count: 3, dest, format: "zip" };
+          }
+          if (method === "world.invalidate") return { invalidated: true };
+          throw new Error(`unmocked: ${method}`);
+        },
+        isReady: () => true,
+        start: async () => {},
+        stop: async () => {},
+      }));
+
+      const tool = getTool("mo2_install")!;
+      const plan = (await tool.handler(
+        { mode: "plan", archive_path: "/tmp/astrogate.zip", mod_name: "Astrogate" },
+        ctx,
+      )) as { ok: boolean; result: { planId: string; lease_token: string } };
+      const apply = (await tool.handler(
+        { mode: "apply", plan_id: plan.result.planId, lease_token: plan.result.lease_token },
+        ctx,
+      )) as { ok: boolean; result: { plugins_registered: string[] } };
+
+      expect(apply.ok).toBe(true);
+      // Pre-fix: files lived at mods/Astrogate/Data/<plugin>.esm.
+      // Post-fix: files at mods/Astrogate/<plugin>.esm (Data/ flattened).
+      expect(existsSync(join(root, "mods", "Astrogate", "Astrogate.esm"))).toBe(true);
+      expect(existsSync(join(root, "mods", "Astrogate", "AstrogateGravJumpMod.esm"))).toBe(true);
+      expect(existsSync(join(root, "mods", "Astrogate", "Astrogate - Main.ba2"))).toBe(true);
+      // Data/ directory should not survive the flatten.
+      expect(existsSync(join(root, "mods", "Astrogate", "Data"))).toBe(false);
+      // plugins.txt registration (BUG-E) — both ESMs added.
+      expect(apply.result.plugins_registered).toEqual([
+        "Astrogate.esm",
+        "AstrogateGravJumpMod.esm",
+      ]);
+    });
+
+    it("does not flatten when plugin already at staging root (most simple archives)", async () => {
+      const { root, ctx } = await _fixture((_root) => ({
+        call: async (method, params) => {
+          if (method === "fomod.parse_choices") throw new Error("not_a_fomod");
+          if (method === "archive.extract_all") {
+            const dest = (params as { dest: string }).dest;
+            await mkdir(dest, { recursive: true });
+            await writeFile(join(dest, "FlatMod.esp"), "fake", "utf8");
+            return { files: ["FlatMod.esp"], file_count: 1, dest, format: "zip" };
+          }
+          if (method === "world.invalidate") return { invalidated: true };
+          throw new Error(`unmocked: ${method}`);
+        },
+        isReady: () => true,
+        start: async () => {},
+        stop: async () => {},
+      }));
+
+      const tool = getTool("mo2_install")!;
+      const plan = (await tool.handler(
+        { mode: "plan", archive_path: "/tmp/flat.zip", mod_name: "FlatMod" },
+        ctx,
+      )) as { ok: boolean; result: { planId: string; lease_token: string } };
+      const apply = (await tool.handler(
+        { mode: "apply", plan_id: plan.result.planId, lease_token: plan.result.lease_token },
+        ctx,
+      )) as { ok: boolean };
+      expect(apply.ok).toBe(true);
+      expect(existsSync(join(root, "mods", "FlatMod", "FlatMod.esp"))).toBe(true);
+    });
+
+    it("flattens single-wrapper subdir without a Data/ name (e.g. <ModName>/plugin.esp)", async () => {
+      const { root, ctx } = await _fixture((_root) => ({
+        call: async (method, params) => {
+          if (method === "fomod.parse_choices") throw new Error("not_a_fomod");
+          if (method === "archive.extract_all") {
+            const dest = (params as { dest: string }).dest;
+            await mkdir(join(dest, "WrappedMod_v1.2"), { recursive: true });
+            await writeFile(
+              join(dest, "WrappedMod_v1.2", "WrappedMod.esp"),
+              "fake",
+              "utf8",
+            );
+            return { files: ["WrappedMod_v1.2/WrappedMod.esp"], file_count: 1, dest, format: "zip" };
+          }
+          if (method === "world.invalidate") return { invalidated: true };
+          throw new Error(`unmocked: ${method}`);
+        },
+        isReady: () => true,
+        start: async () => {},
+        stop: async () => {},
+      }));
+
+      const tool = getTool("mo2_install")!;
+      const plan = (await tool.handler(
+        { mode: "plan", archive_path: "/tmp/wrapped.zip", mod_name: "WrappedMod" },
+        ctx,
+      )) as { ok: boolean; result: { planId: string; lease_token: string } };
+      const apply = (await tool.handler(
+        { mode: "apply", plan_id: plan.result.planId, lease_token: plan.result.lease_token },
+        ctx,
+      )) as { ok: boolean };
+      expect(apply.ok).toBe(true);
+      expect(existsSync(join(root, "mods", "WrappedMod", "WrappedMod.esp"))).toBe(true);
+      expect(existsSync(join(root, "mods", "WrappedMod", "WrappedMod_v1.2"))).toBe(false);
+    });
+
+    it("flattens asset-only mod (textures/ at Data/ wrapper, no plugin)", async () => {
+      const { root, ctx } = await _fixture((_root) => ({
+        call: async (method, params) => {
+          if (method === "fomod.parse_choices") throw new Error("not_a_fomod");
+          if (method === "archive.extract_all") {
+            const dest = (params as { dest: string }).dest;
+            await mkdir(join(dest, "Data", "textures"), { recursive: true });
+            await writeFile(
+              join(dest, "Data", "textures", "diffuse.dds"),
+              Buffer.from("DDS "),
+              "utf8",
+            );
+            return { files: ["Data/textures/diffuse.dds"], file_count: 1, dest, format: "zip" };
+          }
+          if (method === "world.invalidate") return { invalidated: true };
+          throw new Error(`unmocked: ${method}`);
+        },
+        isReady: () => true,
+        start: async () => {},
+        stop: async () => {},
+      }));
+
+      const tool = getTool("mo2_install")!;
+      const plan = (await tool.handler(
+        { mode: "plan", archive_path: "/tmp/textures.zip", mod_name: "TexMod" },
+        ctx,
+      )) as { ok: boolean; result: { planId: string; lease_token: string } };
+      const apply = (await tool.handler(
+        { mode: "apply", plan_id: plan.result.planId, lease_token: plan.result.lease_token },
+        ctx,
+      )) as { ok: boolean; result: { plugins_registered: string[] } };
+      expect(apply.ok).toBe(true);
+      // textures/ at root, no Data/ wrapper survives.
+      expect(existsSync(join(root, "mods", "TexMod", "textures", "diffuse.dds"))).toBe(true);
+      expect(existsSync(join(root, "mods", "TexMod", "Data"))).toBe(false);
+      // No plugins to register for an asset-only mod.
+      expect(apply.result.plugins_registered).toEqual([]);
+    });
+
+    it("BUG-E: plugins.txt is written with the asterisk-enabled prefix and persisted", async () => {
+      const { root, ctx } = await _fixture((_root) => ({
+        call: async (method, params) => {
+          if (method === "fomod.parse_choices") throw new Error("not_a_fomod");
+          if (method === "archive.extract_all") {
+            const dest = (params as { dest: string }).dest;
+            await mkdir(dest, { recursive: true });
+            await writeFile(join(dest, "RegisterMe.esp"), "fake", "utf8");
+            return { files: ["RegisterMe.esp"], file_count: 1, dest, format: "zip" };
+          }
+          if (method === "world.invalidate") return { invalidated: true };
+          throw new Error(`unmocked: ${method}`);
+        },
+        isReady: () => true,
+        start: async () => {},
+        stop: async () => {},
+      }));
+      // Seed plugins.txt with an existing comment + plugin so we can prove
+      // the new line was appended (not overwriting existing content).
+      await writeFile(
+        join(ctx.config.mo2Root, "profiles", "Default", "plugins.txt"),
+        "# existing comment\n*ExistingPlugin.esp\n",
+        "utf8",
+      );
+
+      const tool = getTool("mo2_install")!;
+      const plan = (await tool.handler(
+        { mode: "plan", archive_path: "/tmp/reg.zip", mod_name: "RegisterMeMod" },
+        ctx,
+      )) as { ok: boolean; result: { planId: string; lease_token: string } };
+      const apply = (await tool.handler(
+        { mode: "apply", plan_id: plan.result.planId, lease_token: plan.result.lease_token },
+        ctx,
+      )) as { ok: boolean; result: { plugins_registered: string[] } };
+
+      expect(apply.ok).toBe(true);
+      expect(apply.result.plugins_registered).toEqual(["RegisterMe.esp"]);
+      const pluginsTxt = await readFile(
+        join(root, "profiles", "Default", "plugins.txt"),
+        "utf8",
+      );
+      // Pre-existing content preserved.
+      expect(pluginsTxt).toContain("# existing comment");
+      expect(pluginsTxt).toContain("*ExistingPlugin.esp");
+      // New plugin appended with the FO4/SSE asterisk-enabled prefix.
+      expect(pluginsTxt).toContain("*RegisterMe.esp");
+    });
+
+    it("BUG-E: live broker path calls organizer.refresh after writing plugins.txt", async () => {
+      const { root, ctx } = await _fixture((_root) => ({
+        call: async (method, params) => {
+          if (method === "fomod.parse_choices") throw new Error("not_a_fomod");
+          if (method === "archive.extract_all") {
+            const dest = (params as { dest: string }).dest;
+            await mkdir(dest, { recursive: true });
+            await writeFile(join(dest, "LivePlugin.esp"), "fake", "utf8");
+            return { files: ["LivePlugin.esp"], file_count: 1, dest, format: "zip" };
+          }
+          if (method === "world.invalidate") return { invalidated: true };
+          throw new Error(`unmocked: ${method}`);
+        },
+        isReady: () => true,
+        start: async () => {},
+        stop: async () => {},
+      }));
+      const brokerCalls: string[] = [];
+      ctx.pipeClient = {
+        call: async (method: string) => {
+          brokerCalls.push(method);
+          if (method === "profile.active")
+            return { ok: true, result: { name: "Default" }, error: null };
+          if (method === "installation.create_mod_from_directory") {
+            const absolutePath = join(root, "mods", "LivePluginMod");
+            await mkdir(absolutePath, { recursive: true });
+            return { ok: true, result: { name: "LivePluginMod", absolute_path: absolutePath }, error: null };
+          }
+          if (method === "organizer.refresh")
+            return { ok: true, result: { refreshed: true }, error: null };
+          throw new Error(`unmocked broker: ${method}`);
+        },
+        close: () => {},
+        discoverAndConnect: async () => {},
+        isConnected: () => true,
+      } as unknown as ToolContext["pipeClient"];
+
+      const tool = getTool("mo2_install")!;
+      const plan = (await tool.handler(
+        { mode: "plan", archive_path: "/tmp/live.zip", mod_name: "LivePluginMod" },
+        ctx,
+      )) as { ok: boolean; result: { planId: string; lease_token: string } };
+      const apply = (await tool.handler(
+        { mode: "apply", plan_id: plan.result.planId, lease_token: plan.result.lease_token },
+        ctx,
+      )) as { ok: boolean; result: { plugins_registered: string[] } };
+
+      expect(apply.ok).toBe(true);
+      expect(apply.result.plugins_registered).toEqual(["LivePlugin.esp"]);
+      // organizer.refresh fired after plugins.txt was rewritten so MO2's
+      // in-memory plugin list re-reads the file.
+      expect(brokerCalls).toContain("organizer.refresh");
+    });
   });
 
   it("apply offline path preserves the destPath clobber guard", async () => {

--- a/tools/mo2-mcp/tests/tools/mo2-send-mod-to.test.ts
+++ b/tools/mo2-mcp/tests/tools/mo2-send-mod-to.test.ts
@@ -78,6 +78,160 @@ describe("mo2_send_mod_to", () => {
     expect(plan.ok).toBe(true);
   });
 
+  // BUG-14 BUG-B regression (issue #14): with separators occupying upper-priority
+  // slots, `sep.priority + 1` (full-priority space) overshot the broker validator
+  // `max_priority = len(non_separator_mods)` (non-separator space). Verify the
+  // plan-side computed priority now lives in non-separator space and would pass
+  // the broker validator for BB84's real-world layout.
+  describe("BUG-14 BUG-B: above_separator priority lives in non-separator space", () => {
+    async function _fixtureWithSeparatorsOnTop(): Promise<{
+      root: string;
+      ctx: ToolContext;
+      brokerCalls: Array<{ method: string; payload: unknown }>;
+    }> {
+      const root = await mkdtemp(join(tmpdir(), "mo2-bug-b-"));
+      await mkdir(join(root, "profiles", "Default"), { recursive: true });
+      // 10 lines, 5 separators in upper slots (mimics BB84's distribution
+      // where separators occupy the top of modlist.txt). modCount=10:
+      //   idx=0 Sep1                 -> priority=9 (separator)
+      //   idx=1 Sep2                 -> priority=8 (separator)
+      //   idx=2 Sep3                 -> priority=7 (separator)
+      //   idx=3 TargetSep_separator  -> priority=6 (separator) <- target
+      //   idx=4 Sep5                 -> priority=5 (separator)
+      //   idx=5 Mod1                 -> priority=4
+      //   idx=6 Mod2                 -> priority=3
+      //   idx=7 Mod3                 -> priority=2
+      //   idx=8 Mod4                 -> priority=1
+      //   idx=9 BottomMod            -> priority=0
+      // nonSep.length=5, broker max_priority=5.
+      // OLD: sep.priority + 1 = 7 -> broker rejects (7 > 5).
+      // FIX: nonSepRank(6) = 5 -> clamp(5, 4) = 4 -> accepted.
+      const modlistLines = [
+        "+Sep1_separator",
+        "+Sep2_separator",
+        "+Sep3_separator",
+        "+TargetSep_separator",
+        "+Sep5_separator",
+        "+Mod1",
+        "+Mod2",
+        "+Mod3",
+        "+Mod4",
+        "+BottomMod",
+      ];
+      await writeFile(
+        join(root, "profiles", "Default", "modlist.txt"),
+        modlistLines.join("\n") + "\n",
+        "utf8",
+      );
+      await writeFile(join(root, "profiles", "Default", "plugins.txt"), "", "utf8");
+      await writeFile(
+        join(root, "ModOrganizer.ini"),
+        "[General]\ngame=fallout4\n[Settings]\nbase_directory=" + root + "\n",
+        "utf8",
+      );
+      const brokerCalls: Array<{ method: string; payload: unknown }> = [];
+      const ctx: ToolContext = {
+        config: {
+          mo2Root: root,
+          permissionCeiling: "full-control",
+          allowedProfiles: ["Default"],
+          deny: [],
+          snapshotRoot: join(root, ".mo2-mcp", "snapshots"),
+          auditRoot: join(root, ".mo2-mcp", "audit"),
+        },
+        sessionId: "test",
+        plans: new PlanCache(),
+        snapshots: new SnapshotManager(join(root, ".mo2-mcp", "snapshots"), "test"),
+        audit: new AuditLogger(join(root, ".mo2-mcp", "audit"), "test"),
+      };
+      return { root, ctx, brokerCalls };
+    }
+
+    it("plan diff for above_separator quotes a priority within broker bounds", async () => {
+      const { ctx } = await _fixtureWithSeparatorsOnTop();
+      const tool = getTool("mo2_send_mod_to")!;
+      const plan = (await tool.handler(
+        {
+          mode: "plan",
+          name: "BottomMod",
+          target_mode: "above_separator",
+          target_separator: "TargetSep_separator",
+        },
+        ctx,
+      )) as { ok: boolean; result: { diff: string } };
+      expect(plan.ok).toBe(true);
+      // Extract the integer priority from the diff string.
+      const m = /priority\s+(\d+)/.exec(plan.result.diff);
+      expect(m, `diff string did not include a priority: ${plan.result.diff}`).not.toBeNull();
+      const planPri = Number(m![1]);
+      // Broker max_priority = nonSep.length = 5; valid range [0..5].
+      expect(planPri).toBeGreaterThanOrEqual(0);
+      expect(planPri).toBeLessThanOrEqual(5);
+      // For this fixture nonSepRank(6)=5 -> clamp to nonSep.length-1=4.
+      expect(planPri).toBe(4);
+    });
+
+    it("apply round-trip: live broker receives broker-accepted priority", async () => {
+      const { ctx, brokerCalls } = await _fixtureWithSeparatorsOnTop();
+      ctx.pipeClient = {
+        call: async (method: string, payload: unknown) => {
+          brokerCalls.push({ method, payload });
+          if (method === "profile.active")
+            return { ok: true, result: { name: "Default" }, error: null };
+          if (method === "mods.set_priority") {
+            const p = payload as { priority: number };
+            // Mirror the broker validator (mo2_agent_control.py:991):
+            //   max_priority = max(0, len(non_separator_mods))  // here = 5
+            //   if priority < 0 or priority > max_priority -> reject
+            const maxPriority = 5;
+            if (p.priority < 0 || p.priority > maxPriority) {
+              return {
+                ok: false,
+                error: {
+                  code: "priority_out_of_range",
+                  message: `priority ${p.priority} out of [0..${maxPriority}]`,
+                },
+              };
+            }
+            return { ok: true, result: { actual_priority: p.priority }, error: null };
+          }
+          throw new Error(`unexpected broker method ${method}`);
+        },
+        close: () => {},
+        discoverAndConnect: async () => {},
+        isConnected: () => true,
+      } as unknown as ToolContext["pipeClient"];
+      const tool = getTool("mo2_send_mod_to")!;
+      const planRes = (await tool.handler(
+        {
+          mode: "plan",
+          name: "BottomMod",
+          target_mode: "above_separator",
+          target_separator: "TargetSep_separator",
+        },
+        ctx,
+      )) as { ok: boolean; result: { plan_id: string; lease_token: string } };
+      expect(planRes.ok).toBe(true);
+      const applyRes = (await tool.handler(
+        {
+          mode: "apply",
+          plan_id: planRes.result.plan_id,
+          lease_token: planRes.result.lease_token,
+        },
+        ctx,
+      )) as { ok: boolean; error?: { message: string } };
+      expect(
+        applyRes.ok,
+        `apply rejected by broker: ${applyRes.error?.message ?? "(no error message)"}`,
+      ).toBe(true);
+      const setPri = brokerCalls.find((c) => c.method === "mods.set_priority");
+      expect(setPri, "broker mods.set_priority was not called").toBeDefined();
+      const p = setPri!.payload as { priority: number; name: string };
+      expect(p.name).toBe("BottomMod");
+      expect(p.priority).toBe(4);
+    });
+  });
+
   it("plan with target_mode=above_separator unknown separator throws", async () => {
     const { ctx } = await _fixture();
     const tool = getTool("mo2_send_mod_to")!;


### PR DESCRIPTION
Closes #14.

Fixes all 6 reported bugs in the mo2-mcp T3 `session` / `send_mod_to` / `install` lanes, in 6 source commits + 1 plugin-tree mirror commit. Full vitest suite green (526 → 527 with smoke; 15 new regression tests added across the 6 fixes, 0 regressions in 511 existing).

### Per-bug breakdown

**BUG-A (HIGH) — stale broker pipe after MO2 restart** (commit `bcb338d`)
- Root cause: `PipeClient` cached the pipe name embedding MO2's original PID at `discoverAndConnect` time. After MO2 restart, `endpoint.json` had the new PID, but the cached `pipeName` was never refreshed. Every T3 dispatch failed silently with `ENOENT \\.\pipe\mo2-control-plane-<oldPID>`; `mo2_session` reported `pipeConnected: true` (cached `connectedOnce` flag).
- Fix: `PipeClient.call()` now calls `_maybeRefreshStaleEndpoint()` before each `_rawCall`. Re-reads `endpoint.json` (cheap local file read); if the published endpoint differs from the cached `pipeName`, swaps it in transparently with a stderr warning. Best-effort: missing endpoint falls through to `_rawCall` + existing L1/L2 enrichment.

**BUG-B (HIGH) — `above_separator` priority off-by-one** (commit `5a7ef35`)
- Root cause: plan-side computed `sep.priority + 1` in **full** modlist priority space (separators included in the count), but the broker's `mods.set_priority` validator caps at `len(non_separator_mods)` — and `IModList.setPriority` operates in non-separator priority space. BB84's real-world case: separator at full priority 391 with 30 separators above → plan emitted 392 → broker rejected `priority 392 out of [0..375]`.
- Fix: `_computeTargetPriority` now converts via `nonSepRank(fullPrio) = count of non-separator mods with priority < fullPrio`, applied to `above_separator`, `above_first_conflict`, `below_last_conflict`. Clamped to `[0, nonSep.length - 1]`. `top` stays at `maxNonSepPri`.

**BUG-C (MEDIUM) — `.rar` archives rejected** (commit `7f248fc`)
- Root cause: `archive.py` lumped `.7z` and `.rar` under a single `py7zr.SevenZipFile` branch. py7zr only understands the 7z container; `.rar` produced `Bad7zFile: not a 7z file`.
- Fix: separate `.rar` branch, shell out to `7z.exe` (which handles RAR natively). CLI location precedence: `` → `shutil.which` → well-known Windows install paths. Pre-list members via `7z l -slt` and validate each through the existing `_validate_safe_member` helper.

**BUG-D (HIGH) — silent install corruption (`Data/` not flattened)** (commit `daa4818`)
- Root cause: BGS mod archives commonly wrap content in a top-level `Data/` directory. `mo2_install` didn't flatten this, so the plugin landed at `mods/<name>/Data/<plugin>.esm` and MO2's VFS projected it as `<game>/Data/Data/<plugin>.esm` — silently invisible to the engine. Astrogate v5.8 #9363 was the real-world repro.
- Fix: new `_flattenBgsArchive` heuristic. Detects mod root via plugin extensions (.esm/.esp/.esl) or known BGS asset directories (meshes, textures, scripts, fomod, sfse/skse/f4se, etc.). Recurses single-subdir wrappers up to depth 4. Moves the root's contents up to staging and cleans the now-empty intermediate dirs. FOMOD-staged installs unaffected (their source→destination map already explicit).

**BUG-E (HIGH) — atomic-install contract broken** (commit `daa4818`)
- Root cause: install completed `successfully` but plugins.txt was never updated; the agent had to do a separate N×`toggle_plugin` round-trip to actually activate.
- Fix: new `_registerPluginsInPluginsTxt` enumerates plugin files at the final mod root, appends asterisk-prefixed entries (FO4/SSE convention = enabled), preserves existing comments/entries via case-insensitive match. Live broker path calls `organizer.refresh({save_changes: false})` after the write so MO2's in-memory plugin list re-reads from disk. `plugins.txt` added to `affectedFiles` + lease targets so rollback restores it.

**BUG-F (MEDIUM) — install lease blocks parallel plans** (commit `f55cf39`)
- Root cause: plan-side acquired a filesystem lease lock on the profile's `modlist.txt` (now `plugins.txt` too), so concurrent `mo2_install` plans for distinct `mod_names` all contended on the same lock and the second+ failed with `lease_held`. Forced serial plan+apply round-trips for multi-mod batches.
- Fix: new `PlanApplyHandler.acquirePlanLock?: boolean` (default `true`; legacy behavior preserved for every other tool). When `false`, `runPlanMode` records the lease fingerprint without acquiring an FS lock; `runApplyMode` acquires the lock at the apply boundary, runs `verifyLease` (catches inter-plan drift via the stored fingerprint), mutates, releases in `finally`. `mo2_install` opts in.

### Real-world impact

For BB84's reported install batch:
- Pre-fix: 25% of mods installable via `mo2_install`; rest required bash workarounds.
- Post-fix: every reported failure case has a regression test that proves the corrected behavior. Plan-mode fan-out for multi-mod batches is now ~2x throughput.

### Testing

| Bug | Test file | New cases |
|---|---|---|
| BUG-A | `tests/pipe-client.stale-endpoint.test.ts` | 5 (no-op when mo2Root unset, no-op when endpoint absent, no-op when endpoint unchanged, auto-rebinds on PID change, normalizes full `\\.\pipe\` prefix) |
| BUG-B | `tests/tools/mo2-send-mod-to.test.ts` | 2 (plan diff stays within broker bounds; apply round-trip against broker-validator mock succeeds with priority 4 in 10-mod-5-separator fixture) |
| BUG-C | `tools/mo2-mcp-sidecar/tests/test_archive.py` | 4 (env override, missing 7z error, routes through 7z.exe not py7zr, exit code propagation) |
| BUG-D + E | `tests/tools/mo2-install.test.ts` | 5 (Astrogate Data/ flatten, no-op when already flat, ModName/ wrapper flatten, asset-only mod, plugins.txt write with asterisk + organizer.refresh on live path) |
| BUG-F | `tests/tools/mo2-install.test.ts` | 2 (3 parallel plans all ok:true; apply serializes via lease_violation on 2nd) |

### Files changed

| Layer | Files |
|---|---|
| Source (6 commits) | `tools/mo2-mcp/src/{pipe-client,plan-apply,tools/mo2-install,tools/mo2-send-mod-to}.ts`, `tools/mo2-mcp-sidecar/src/mo2_mcp_sidecar/archive.py`, 4 test files |
| Plugin-tree mirror (1 commit) | mirrored `plugins/bgs-modding-superpowers/tools/mo2-mcp/{src,dist}/...` + `plugins/bgs-modding-superpowers/tools/mo2-mcp-sidecar/{src,tests}/...` |
| Excluded from staging | ~3.7k node_modules LF/CRLF rendering churn from this machine's npm install regen (not a semantic change) |

### Broker redeploy required?

No. All fixes are in the TS MCP layer + sidecar Python. The Python broker (`tools/mo2-control-plane/live-bridge/mo2_agent_control.py`) is unchanged.