### PR TITLE
fix(mo2-mcp): send_mod_to uses full priority space (BUG-2026-06-27)

### DIFF
--- a/plugins/bgs-modding-superpowers/tools/mo2-control-plane/live-bridge/mo2_agent_control.py
+++ b/plugins/bgs-modding-superpowers/tools/mo2-control-plane/live-bridge/mo2_agent_control.py
@@ -987,9 +987,16 @@ def _handle_mods_set_priority(organizer, pump, payload):
         if mod_list.getMod(name) is None:
             return ("error", ErrorCode.MOD_NOT_FOUND, f"mod '{name}' not found")
 
+        # docs/issues/BUG-mo2-mcp-send_mod_to-semantics-2026-06-27.md:
+        # mobase.IModList.setPriority operates in FULL priority space —
+        # separators occupy slots like regular mods. The previous validator
+        # excluded separators from the cap, which rejected valid cross-section
+        # placements near high-priority separators. MO2's real clamp is
+        # [0, m_NumRegularMods - 1], where m_NumRegularMods includes regular,
+        # foreign, and separator mods, excluding only overwrite/backups.
+        # allMods() already excludes overwrite/backups and includes separators.
         all_mods = list(mod_list.allMods())
-        non_separator_mods = [mod_name for mod_name in all_mods if not mod_name.endswith("_separator")]
-        max_priority = max(0, len(non_separator_mods))
+        max_priority = max(0, len(all_mods) - 1)
         if priority < 0 or priority > max_priority:
             return (
                 "error",

--- a/plugins/bgs-modding-superpowers/tools/mo2-control-plane/live-bridge/tests/test_broker_mods_commands.py
+++ b/plugins/bgs-modding-superpowers/tools/mo2-control-plane/live-bridge/tests/test_broker_mods_commands.py
@@ -243,6 +243,61 @@ def test_mods_set_priority_out_of_range(monkeypatch):
     assert result["error"]["code"] == "priority_out_of_range"
 
 
+def test_mods_set_priority_out_of_range_high(monkeypatch):
+    """New validator (BUG-mo2-mcp-send_mod_to-semantics-2026-06-27): full
+    priority space, max = len(all_mods) - 1. Mods [A,B] -> max=1, priority 2 rejected."""
+    bridge = _load_bridge(monkeypatch)
+    mod_list = MagicMock()
+    mod_list.getMod.return_value = MagicMock()
+    mod_list.allMods.return_value = ["ModA", "ModB"]
+    organizer = MagicMock()
+    organizer.modList.return_value = mod_list
+    pump = MagicMock()
+    pump.invoke_blocking.side_effect = lambda fn, timeout_s=10: fn()
+    result = bridge._handle_mods_set_priority(organizer, pump, {"name": "ModA", "priority": 2})
+    assert result["ok"] is False
+    assert result["error"]["code"] == "priority_out_of_range"
+    assert "[0..1]" in result["error"]["message"]
+
+
+def test_mods_set_priority_separators_count_in_validator(monkeypatch):
+    """Regression for docs/issues/BUG-mo2-mcp-send_mod_to-semantics-2026-06-27.md.
+
+    Prior (buggy) validator excluded separators from max_priority, capping at
+    len(non_separator_mods). With this profile (3 separators + 2 mods = 5 total),
+    the OLD validator would cap at 2; the NEW validator caps at 4 (= len - 1).
+    setPriority(name, 3) must be ACCEPTED to land the mod above a separator.
+    """
+    bridge = _load_bridge(monkeypatch)
+    actual = {"current": 0}
+    mod_list = MagicMock()
+    mod_list.getMod.return_value = MagicMock()
+    # 3 separators in upper slots + 2 mods. Real-world BB84 pattern.
+    mod_list.allMods.return_value = [
+        "Top_separator",
+        "Mid_separator",
+        "Low_separator",
+        "ModA",
+        "ModB",
+    ]
+
+    def _set(_name, priority):
+        actual["current"] = priority
+
+    mod_list.setPriority.side_effect = _set
+    mod_list.priority.side_effect = lambda _name: actual["current"]
+
+    organizer = MagicMock()
+    organizer.modList.return_value = mod_list
+    pump = MagicMock()
+    pump.invoke_blocking.side_effect = lambda fn, timeout_s=10: fn()
+
+    result = bridge._handle_mods_set_priority(organizer, pump, {"name": "ModA", "priority": 3})
+    assert result["ok"] is True, f"separator slot rejected: {result.get('error')}"
+    assert result["result"]["requested_priority"] == 3
+    assert result["result"]["actual_priority"] == 3
+
+
 def test_mods_rename_success(monkeypatch):
     bridge = _load_bridge(monkeypatch)
 

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/tools/mo2-send-mod-to.js
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/tools/mo2-send-mod-to.js
@@ -5,7 +5,7 @@
  *   - top: highest priority (numerically priority-count-1)
  *   - bottom: lowest priority (priority 0)
  *   - priority: explicit integer
- *   - above_separator: place above named separator (separator priority + 1)
+ *   - above_separator: place above named separator (separator priority + 1 in FULL priority space)
  *   - above_first_conflict: place above highest-priority mod that shares files (sidecar)
  *   - below_last_conflict: place below lowest-priority mod that shares files (sidecar)
  */
@@ -43,39 +43,31 @@ const inputSchema = z.discriminatedUnion("mode", [
 async function _computeTargetPriority(args, ctx, profile) {
     const bound = requireBoundContext(ctx);
     const p = await readProfile(join(bound.config.mo2Root, "profiles", profile));
-    const nonSep = p.mods.filter((m) => !m.isSeparator);
+    // FULL priority space (separators occupy slots). mobase IModList.setPriority
+    // accepts priorities in this space — valid range [0, mods.length - 1]. The
+    // 2026-06-17 BUG-B fix (issue #14) introduced nonSepRank conversion based on
+    // a wrong conclusion about broker semantics; that fix is reverted here.
+    // See docs/issues/BUG-mo2-mcp-send_mod_to-semantics-2026-06-27.md.
+    const maxPri = Math.max(0, p.mods.length - 1);
+    const clamp = (v) => Math.max(0, Math.min(v, maxPri));
     const mode = args.target_mode;
-    // BUG-14 BUG-B fix (issue #14): the broker's `mods.set_priority`
-    // validates `priority <= len(non_separator_mods)` and then calls
-    // mobase.IModList.setPriority in non-separator priority space.
-    // `profile-reader.ts` assigns priorities from the FULL modlist.txt
-    // line count (which includes separators). So a value computed in
-    // full-priority space (e.g. `sep.priority + 1`) overshoots the
-    // broker validator whenever separators occupy upper slots — the
-    // real-world BB84 case: separator at full priority 391 with 30
-    // separators above produced plan→392, broker rejected with
-    // "priority 392 out of [0..375]".
-    //
-    // Convert via `nonSepRank(fullPrio)` = count of non-separator mods
-    // strictly below `fullPrio` in full-priority space. That count is
-    // exactly the non-separator slot just above the given full-prio
-    // position. Clamp to [0, nonSep.length - 1] to stay within broker
-    // bounds.
-    const nonSepRank = (fullPrio) => nonSep.filter((m) => m.priority < fullPrio).length;
-    const maxNonSepPri = Math.max(0, nonSep.length - 1);
-    const clamp = (v) => Math.max(0, Math.min(v, maxNonSepPri));
     switch (mode) {
         case "top":
-            return maxNonSepPri;
+            // Highest priority = bottom of MO2 GUI = top of modlist.txt = wins
+            return maxPri;
         case "bottom":
+            // Priority 0 = top of MO2 GUI = bottom of modlist.txt = loses
             return 0;
         case "priority":
-            return args.target_priority ?? 0;
+            return clamp(args.target_priority ?? 0);
         case "above_separator": {
             const sep = p.mods.find((m) => m.isSeparator && m.name === args.target_separator);
             if (!sep)
                 throw new Error(`separator_not_found: ${args.target_separator}`);
-            return clamp(nonSepRank(sep.priority));
+            // "Above" the separator visually = higher priority numerically (closer to
+            // bottom of MO2 GUI). Place mod at sep.priority + 1; clamp guards against
+            // separators at the very top.
+            return clamp(sep.priority + 1);
         }
         case "above_first_conflict":
         case "below_last_conflict": {
@@ -93,16 +85,17 @@ async function _computeTargetPriority(args, ctx, profile) {
             if (conflictMods.length === 0) {
                 throw new Error("no_conflicts_found");
             }
-            const conflictRanks = conflictMods
+            // Use FULL priorities directly, no nonSepRank conversion.
+            const conflictPris = conflictMods
                 .map((n) => p.mods.find((m) => m.name === n))
                 .filter((m) => m !== undefined && !m.isSeparator)
-                .map((m) => nonSepRank(m.priority));
-            if (conflictRanks.length === 0) {
+                .map((m) => m.priority);
+            if (conflictPris.length === 0) {
                 throw new Error("no_conflicts_found");
             }
             if (mode === "above_first_conflict")
-                return clamp(Math.max(...conflictRanks) + 1);
-            return clamp(Math.min(...conflictRanks) - 1);
+                return clamp(Math.max(...conflictPris) + 1);
+            return clamp(Math.min(...conflictPris) - 1);
         }
         default:
             throw new Error(`unknown_mode: ${mode}`);

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/src/tools/mo2-send-mod-to.ts
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/src/tools/mo2-send-mod-to.ts
@@ -5,7 +5,7 @@
  *   - top: highest priority (numerically priority-count-1)
  *   - bottom: lowest priority (priority 0)
  *   - priority: explicit integer
- *   - above_separator: place above named separator (separator priority + 1)
+ *   - above_separator: place above named separator (separator priority + 1 in FULL priority space)
  *   - above_first_conflict: place above highest-priority mod that shares files (sidecar)
  *   - below_last_conflict: place below lowest-priority mod that shares files (sidecar)
  */
@@ -51,41 +51,31 @@ async function _computeTargetPriority(
 ): Promise<number> {
   const bound = requireBoundContext(ctx);
   const p = await readProfile(join(bound.config.mo2Root, "profiles", profile));
-  const nonSep = p.mods.filter((m) => !m.isSeparator);
+  // FULL priority space (separators occupy slots). mobase IModList.setPriority
+  // accepts priorities in this space — valid range [0, mods.length - 1]. The
+  // 2026-06-17 BUG-B fix (issue #14) introduced nonSepRank conversion based on
+  // a wrong conclusion about broker semantics; that fix is reverted here.
+  // See docs/issues/BUG-mo2-mcp-send_mod_to-semantics-2026-06-27.md.
+  const maxPri = Math.max(0, p.mods.length - 1);
+  const clamp = (v: number): number => Math.max(0, Math.min(v, maxPri));
   const mode = args.target_mode as string;
-
-  // BUG-14 BUG-B fix (issue #14): the broker's `mods.set_priority`
-  // validates `priority <= len(non_separator_mods)` and then calls
-  // mobase.IModList.setPriority in non-separator priority space.
-  // `profile-reader.ts` assigns priorities from the FULL modlist.txt
-  // line count (which includes separators). So a value computed in
-  // full-priority space (e.g. `sep.priority + 1`) overshoots the
-  // broker validator whenever separators occupy upper slots — the
-  // real-world BB84 case: separator at full priority 391 with 30
-  // separators above produced plan→392, broker rejected with
-  // "priority 392 out of [0..375]".
-  //
-  // Convert via `nonSepRank(fullPrio)` = count of non-separator mods
-  // strictly below `fullPrio` in full-priority space. That count is
-  // exactly the non-separator slot just above the given full-prio
-  // position. Clamp to [0, nonSep.length - 1] to stay within broker
-  // bounds.
-  const nonSepRank = (fullPrio: number): number =>
-    nonSep.filter((m) => m.priority < fullPrio).length;
-  const maxNonSepPri = Math.max(0, nonSep.length - 1);
-  const clamp = (v: number): number => Math.max(0, Math.min(v, maxNonSepPri));
 
   switch (mode) {
     case "top":
-      return maxNonSepPri;
+      // Highest priority = bottom of MO2 GUI = top of modlist.txt = wins
+      return maxPri;
     case "bottom":
+      // Priority 0 = top of MO2 GUI = bottom of modlist.txt = loses
       return 0;
     case "priority":
-      return (args.target_priority as number) ?? 0;
+      return clamp((args.target_priority as number) ?? 0);
     case "above_separator": {
       const sep = p.mods.find((m) => m.isSeparator && m.name === args.target_separator);
       if (!sep) throw new Error(`separator_not_found: ${args.target_separator}`);
-      return clamp(nonSepRank(sep.priority));
+      // "Above" the separator visually = higher priority numerically (closer to
+      // bottom of MO2 GUI). Place mod at sep.priority + 1; clamp guards against
+      // separators at the very top.
+      return clamp(sep.priority + 1);
     }
     case "above_first_conflict":
     case "below_last_conflict": {
@@ -103,15 +93,16 @@ async function _computeTargetPriority(
       if (conflictMods.length === 0) {
         throw new Error("no_conflicts_found");
       }
-      const conflictRanks = conflictMods
+      // Use FULL priorities directly, no nonSepRank conversion.
+      const conflictPris = conflictMods
         .map((n) => p.mods.find((m) => m.name === n))
         .filter((m): m is (typeof p.mods)[number] => m !== undefined && !m.isSeparator)
-        .map((m) => nonSepRank(m.priority));
-      if (conflictRanks.length === 0) {
+        .map((m) => m.priority);
+      if (conflictPris.length === 0) {
         throw new Error("no_conflicts_found");
       }
-      if (mode === "above_first_conflict") return clamp(Math.max(...conflictRanks) + 1);
-      return clamp(Math.min(...conflictRanks) - 1);
+      if (mode === "above_first_conflict") return clamp(Math.max(...conflictPris) + 1);
+      return clamp(Math.min(...conflictPris) - 1);
     }
     default:
       throw new Error(`unknown_mode: ${mode}`);

--- a/tools/mo2-control-plane/live-bridge/mo2_agent_control.py
+++ b/tools/mo2-control-plane/live-bridge/mo2_agent_control.py
@@ -987,9 +987,16 @@ def _handle_mods_set_priority(organizer, pump, payload):
         if mod_list.getMod(name) is None:
             return ("error", ErrorCode.MOD_NOT_FOUND, f"mod '{name}' not found")
 
+        # docs/issues/BUG-mo2-mcp-send_mod_to-semantics-2026-06-27.md:
+        # mobase.IModList.setPriority operates in FULL priority space —
+        # separators occupy slots like regular mods. The previous validator
+        # excluded separators from the cap, which rejected valid cross-section
+        # placements near high-priority separators. MO2's real clamp is
+        # [0, m_NumRegularMods - 1], where m_NumRegularMods includes regular,
+        # foreign, and separator mods, excluding only overwrite/backups.
+        # allMods() already excludes overwrite/backups and includes separators.
         all_mods = list(mod_list.allMods())
-        non_separator_mods = [mod_name for mod_name in all_mods if not mod_name.endswith("_separator")]
-        max_priority = max(0, len(non_separator_mods))
+        max_priority = max(0, len(all_mods) - 1)
         if priority < 0 or priority > max_priority:
             return (
                 "error",

--- a/tools/mo2-control-plane/live-bridge/tests/test_broker_mods_commands.py
+++ b/tools/mo2-control-plane/live-bridge/tests/test_broker_mods_commands.py
@@ -243,6 +243,61 @@ def test_mods_set_priority_out_of_range(monkeypatch):
     assert result["error"]["code"] == "priority_out_of_range"
 
 
+def test_mods_set_priority_out_of_range_high(monkeypatch):
+    """New validator (BUG-mo2-mcp-send_mod_to-semantics-2026-06-27): full
+    priority space, max = len(all_mods) - 1. Mods [A,B] -> max=1, priority 2 rejected."""
+    bridge = _load_bridge(monkeypatch)
+    mod_list = MagicMock()
+    mod_list.getMod.return_value = MagicMock()
+    mod_list.allMods.return_value = ["ModA", "ModB"]
+    organizer = MagicMock()
+    organizer.modList.return_value = mod_list
+    pump = MagicMock()
+    pump.invoke_blocking.side_effect = lambda fn, timeout_s=10: fn()
+    result = bridge._handle_mods_set_priority(organizer, pump, {"name": "ModA", "priority": 2})
+    assert result["ok"] is False
+    assert result["error"]["code"] == "priority_out_of_range"
+    assert "[0..1]" in result["error"]["message"]
+
+
+def test_mods_set_priority_separators_count_in_validator(monkeypatch):
+    """Regression for docs/issues/BUG-mo2-mcp-send_mod_to-semantics-2026-06-27.md.
+
+    Prior (buggy) validator excluded separators from max_priority, capping at
+    len(non_separator_mods). With this profile (3 separators + 2 mods = 5 total),
+    the OLD validator would cap at 2; the NEW validator caps at 4 (= len - 1).
+    setPriority(name, 3) must be ACCEPTED to land the mod above a separator.
+    """
+    bridge = _load_bridge(monkeypatch)
+    actual = {"current": 0}
+    mod_list = MagicMock()
+    mod_list.getMod.return_value = MagicMock()
+    # 3 separators in upper slots + 2 mods. Real-world BB84 pattern.
+    mod_list.allMods.return_value = [
+        "Top_separator",
+        "Mid_separator",
+        "Low_separator",
+        "ModA",
+        "ModB",
+    ]
+
+    def _set(_name, priority):
+        actual["current"] = priority
+
+    mod_list.setPriority.side_effect = _set
+    mod_list.priority.side_effect = lambda _name: actual["current"]
+
+    organizer = MagicMock()
+    organizer.modList.return_value = mod_list
+    pump = MagicMock()
+    pump.invoke_blocking.side_effect = lambda fn, timeout_s=10: fn()
+
+    result = bridge._handle_mods_set_priority(organizer, pump, {"name": "ModA", "priority": 3})
+    assert result["ok"] is True, f"separator slot rejected: {result.get('error')}"
+    assert result["result"]["requested_priority"] == 3
+    assert result["result"]["actual_priority"] == 3
+
+
 def test_mods_rename_success(monkeypatch):
     bridge = _load_bridge(monkeypatch)
 

--- a/tools/mo2-mcp/src/tools/mo2-send-mod-to.ts
+++ b/tools/mo2-mcp/src/tools/mo2-send-mod-to.ts
@@ -5,7 +5,7 @@
  *   - top: highest priority (numerically priority-count-1)
  *   - bottom: lowest priority (priority 0)
  *   - priority: explicit integer
- *   - above_separator: place above named separator (separator priority + 1)
+ *   - above_separator: place above named separator (separator priority + 1 in FULL priority space)
  *   - above_first_conflict: place above highest-priority mod that shares files (sidecar)
  *   - below_last_conflict: place below lowest-priority mod that shares files (sidecar)
  */
@@ -51,41 +51,31 @@ async function _computeTargetPriority(
 ): Promise<number> {
   const bound = requireBoundContext(ctx);
   const p = await readProfile(join(bound.config.mo2Root, "profiles", profile));
-  const nonSep = p.mods.filter((m) => !m.isSeparator);
+  // FULL priority space (separators occupy slots). mobase IModList.setPriority
+  // accepts priorities in this space — valid range [0, mods.length - 1]. The
+  // 2026-06-17 BUG-B fix (issue #14) introduced nonSepRank conversion based on
+  // a wrong conclusion about broker semantics; that fix is reverted here.
+  // See docs/issues/BUG-mo2-mcp-send_mod_to-semantics-2026-06-27.md.
+  const maxPri = Math.max(0, p.mods.length - 1);
+  const clamp = (v: number): number => Math.max(0, Math.min(v, maxPri));
   const mode = args.target_mode as string;
-
-  // BUG-14 BUG-B fix (issue #14): the broker's `mods.set_priority`
-  // validates `priority <= len(non_separator_mods)` and then calls
-  // mobase.IModList.setPriority in non-separator priority space.
-  // `profile-reader.ts` assigns priorities from the FULL modlist.txt
-  // line count (which includes separators). So a value computed in
-  // full-priority space (e.g. `sep.priority + 1`) overshoots the
-  // broker validator whenever separators occupy upper slots — the
-  // real-world BB84 case: separator at full priority 391 with 30
-  // separators above produced plan→392, broker rejected with
-  // "priority 392 out of [0..375]".
-  //
-  // Convert via `nonSepRank(fullPrio)` = count of non-separator mods
-  // strictly below `fullPrio` in full-priority space. That count is
-  // exactly the non-separator slot just above the given full-prio
-  // position. Clamp to [0, nonSep.length - 1] to stay within broker
-  // bounds.
-  const nonSepRank = (fullPrio: number): number =>
-    nonSep.filter((m) => m.priority < fullPrio).length;
-  const maxNonSepPri = Math.max(0, nonSep.length - 1);
-  const clamp = (v: number): number => Math.max(0, Math.min(v, maxNonSepPri));
 
   switch (mode) {
     case "top":
-      return maxNonSepPri;
+      // Highest priority = bottom of MO2 GUI = top of modlist.txt = wins
+      return maxPri;
     case "bottom":
+      // Priority 0 = top of MO2 GUI = bottom of modlist.txt = loses
       return 0;
     case "priority":
-      return (args.target_priority as number) ?? 0;
+      return clamp((args.target_priority as number) ?? 0);
     case "above_separator": {
       const sep = p.mods.find((m) => m.isSeparator && m.name === args.target_separator);
       if (!sep) throw new Error(`separator_not_found: ${args.target_separator}`);
-      return clamp(nonSepRank(sep.priority));
+      // "Above" the separator visually = higher priority numerically (closer to
+      // bottom of MO2 GUI). Place mod at sep.priority + 1; clamp guards against
+      // separators at the very top.
+      return clamp(sep.priority + 1);
     }
     case "above_first_conflict":
     case "below_last_conflict": {
@@ -103,15 +93,16 @@ async function _computeTargetPriority(
       if (conflictMods.length === 0) {
         throw new Error("no_conflicts_found");
       }
-      const conflictRanks = conflictMods
+      // Use FULL priorities directly, no nonSepRank conversion.
+      const conflictPris = conflictMods
         .map((n) => p.mods.find((m) => m.name === n))
         .filter((m): m is (typeof p.mods)[number] => m !== undefined && !m.isSeparator)
-        .map((m) => nonSepRank(m.priority));
-      if (conflictRanks.length === 0) {
+        .map((m) => m.priority);
+      if (conflictPris.length === 0) {
         throw new Error("no_conflicts_found");
       }
-      if (mode === "above_first_conflict") return clamp(Math.max(...conflictRanks) + 1);
-      return clamp(Math.min(...conflictRanks) - 1);
+      if (mode === "above_first_conflict") return clamp(Math.max(...conflictPris) + 1);
+      return clamp(Math.min(...conflictPris) - 1);
     }
     default:
       throw new Error(`unknown_mode: ${mode}`);

--- a/tools/mo2-mcp/tests/tools/mo2-send-mod-to.test.ts
+++ b/tools/mo2-mcp/tests/tools/mo2-send-mod-to.test.ts
@@ -78,12 +78,12 @@ describe("mo2_send_mod_to", () => {
     expect(plan.ok).toBe(true);
   });
 
-  // BUG-14 BUG-B regression (issue #14): with separators occupying upper-priority
-  // slots, `sep.priority + 1` (full-priority space) overshot the broker validator
-  // `max_priority = len(non_separator_mods)` (non-separator space). Verify the
-  // plan-side computed priority now lives in non-separator space and would pass
-  // the broker validator for BB84's real-world layout.
-  describe("BUG-14 BUG-B: above_separator priority lives in non-separator space", () => {
+  // BUG-mo2-mcp-send_mod_to-semantics-2026-06-27 regression: mobase
+  // IModList.setPriority operates in FULL priority space. Separators occupy
+  // slots, so above_separator should pass sep.priority + 1 directly instead of
+  // converting through nonSepRank(). Verify plan/apply uses the corrected full
+  // priority value that the broker validator now accepts.
+  describe("BUG-mo2-mcp-send_mod_to-semantics-2026-06-27: above_separator uses FULL priority space", () => {
     async function _fixtureWithSeparatorsOnTop(): Promise<{
       root: string;
       ctx: ToolContext;
@@ -103,9 +103,9 @@ describe("mo2_send_mod_to", () => {
       //   idx=7 Mod3                 -> priority=2
       //   idx=8 Mod4                 -> priority=1
       //   idx=9 BottomMod            -> priority=0
-      // nonSep.length=5, broker max_priority=5.
-      // OLD: sep.priority + 1 = 7 -> broker rejects (7 > 5).
-      // FIX: nonSepRank(6) = 5 -> clamp(5, 4) = 4 -> accepted.
+      // Correct full-space semantics: max priority = mod_count - 1 = 9.
+      // TargetSep_separator priority = 6; above separator = 7. OLD BUG-B
+      // nonSepRank conversion returned 4, landing in the wrong section.
       const modlistLines = [
         "+Sep1_separator",
         "+Sep2_separator",
@@ -164,11 +164,11 @@ describe("mo2_send_mod_to", () => {
       const m = /priority\s+(\d+)/.exec(plan.result.diff);
       expect(m, `diff string did not include a priority: ${plan.result.diff}`).not.toBeNull();
       const planPri = Number(m![1]);
-      // Broker max_priority = nonSep.length = 5; valid range [0..5].
+      // Broker max_priority = mod_count - 1 = 9; valid range [0..9].
       expect(planPri).toBeGreaterThanOrEqual(0);
-      expect(planPri).toBeLessThanOrEqual(5);
-      // For this fixture nonSepRank(6)=5 -> clamp to nonSep.length-1=4.
-      expect(planPri).toBe(4);
+      expect(planPri).toBeLessThanOrEqual(9);
+      // TargetSep_separator at priority 6; sep.priority + 1 = 7.
+      expect(planPri).toBe(7);
     });
 
     it("apply round-trip: live broker receives broker-accepted priority", async () => {
@@ -180,10 +180,10 @@ describe("mo2_send_mod_to", () => {
             return { ok: true, result: { name: "Default" }, error: null };
           if (method === "mods.set_priority") {
             const p = payload as { priority: number };
-            // Mirror the broker validator (mo2_agent_control.py:991):
-            //   max_priority = max(0, len(non_separator_mods))  // here = 5
+            // Mirror the corrected broker validator:
+            //   max_priority = max(0, mod_count - 1)  // here = 9
             //   if priority < 0 or priority > max_priority -> reject
-            const maxPriority = 5;
+            const maxPriority = 9;
             if (p.priority < 0 || p.priority > maxPriority) {
               return {
                 ok: false,
@@ -228,7 +228,215 @@ describe("mo2_send_mod_to", () => {
       expect(setPri, "broker mods.set_priority was not called").toBeDefined();
       const p = setPri!.payload as { priority: number; name: string };
       expect(p.name).toBe("BottomMod");
-      expect(p.priority).toBe(4);
+      expect(p.priority).toBe(7);
+    });
+  });
+
+  // docs/issues/BUG-mo2-mcp-send_mod_to-semantics-2026-06-27.md: real-world
+  // curator pattern with multiple separators between current mod and target
+  // section. Mod at low priority should be movable to high-priority section
+  // above a named separator without the broker rejecting.
+  describe("BUG-mo2-mcp-send_mod_to-semantics-2026-06-27 real-world regression", () => {
+    it("above_separator: mid-list mod targets upper separator, full-space priority", async () => {
+      const root = await mkdtemp(join(tmpdir(), "mo2-bb84-real-"));
+      await mkdir(join(root, "profiles", "Default"), { recursive: true });
+      // modlist.txt is REVERSE order: top of file = highest priority.
+      // 12 lines, 4 separators distributed through the list:
+      //   line 0 priority 11: TopSep_separator    (above target zone)
+      //   line 1 priority 10: ZoneMod1            (target zone)
+      //   line 2 priority  9: ZoneMod2            (target zone)
+      //   line 3 priority  8: TargetSep_separator <- agent targets this
+      //   line 4 priority  7: BelowMod1
+      //   line 5 priority  6: MidSep_separator
+      //   line 6 priority  5: BelowMod2
+      //   line 7 priority  4: BelowMod3
+      //   line 8 priority  3: BottomSep_separator
+      //   line 9 priority  2: SourceMod           <- the mod we want to move
+      //   line 10 priority 1: BelowMod4
+      //   line 11 priority 0: BelowMod5
+      // SourceMod is at priority 2; agent wants it above TargetSep_separator
+      // (priority 8). Expected: sep.priority + 1 = 9, broker accepts.
+      const modlistLines = [
+        "+TopSep_separator",
+        "+ZoneMod1",
+        "+ZoneMod2",
+        "+TargetSep_separator",
+        "+BelowMod1",
+        "+MidSep_separator",
+        "+BelowMod2",
+        "+BelowMod3",
+        "+BottomSep_separator",
+        "+SourceMod",
+        "+BelowMod4",
+        "+BelowMod5",
+      ];
+      await writeFile(
+        join(root, "profiles", "Default", "modlist.txt"),
+        modlistLines.join("\n") + "\n",
+        "utf8",
+      );
+      await writeFile(join(root, "profiles", "Default", "plugins.txt"), "", "utf8");
+      await writeFile(
+        join(root, "ModOrganizer.ini"),
+        "[General]\ngame=fallout4\n[Settings]\nbase_directory=" + root + "\n",
+        "utf8",
+      );
+
+      const brokerCalls: Array<{ method: string; payload: unknown }> = [];
+      const ctx: ToolContext = {
+        config: {
+          mo2Root: root,
+          permissionCeiling: "full-control",
+          allowedProfiles: ["Default"],
+          deny: [],
+          snapshotRoot: join(root, ".mo2-mcp", "snapshots"),
+          auditRoot: join(root, ".mo2-mcp", "audit"),
+        },
+        sessionId: "test",
+        plans: new PlanCache(),
+        snapshots: new SnapshotManager(join(root, ".mo2-mcp", "snapshots"), "test"),
+        audit: new AuditLogger(join(root, ".mo2-mcp", "audit"), "test"),
+      };
+      ctx.pipeClient = {
+        call: async (method: string, payload: unknown) => {
+          brokerCalls.push({ method, payload });
+          if (method === "profile.active")
+            return { ok: true, result: { name: "Default" }, error: null };
+          if (method === "mods.set_priority") {
+            const p = payload as { priority: number };
+            // New broker validator: max = mod_count - 1 = 11
+            const maxPriority = 11;
+            if (p.priority < 0 || p.priority > maxPriority) {
+              return {
+                ok: false,
+                error: {
+                  code: "priority_out_of_range",
+                  message: `priority ${p.priority} out of [0..${maxPriority}]`,
+                },
+              };
+            }
+            return { ok: true, result: { actual_priority: p.priority }, error: null };
+          }
+          throw new Error(`unexpected broker method ${method}`);
+        },
+        close: () => {},
+        discoverAndConnect: async () => {},
+        isConnected: () => true,
+      } as unknown as ToolContext["pipeClient"];
+
+      const tool = getTool("mo2_send_mod_to")!;
+      const planRes = (await tool.handler(
+        {
+          mode: "plan",
+          name: "SourceMod",
+          target_mode: "above_separator",
+          target_separator: "TargetSep_separator",
+        },
+        ctx,
+      )) as { ok: boolean; result: { diff: string; plan_id: string; lease_token: string } };
+      expect(planRes.ok).toBe(true);
+      const m = /priority\s+(\d+)/.exec(planRes.result.diff);
+      expect(m).not.toBeNull();
+      // TargetSep_separator at priority 8; sep.priority + 1 = 9
+      expect(Number(m![1])).toBe(9);
+
+      const applyRes = (await tool.handler(
+        {
+          mode: "apply",
+          plan_id: planRes.result.plan_id,
+          lease_token: planRes.result.lease_token,
+        },
+        ctx,
+      )) as { ok: boolean; error?: { message: string } };
+      expect(
+        applyRes.ok,
+        `apply rejected by broker: ${applyRes.error?.message ?? "(no error message)"}`,
+      ).toBe(true);
+      const setPri = brokerCalls.find((c) => c.method === "mods.set_priority");
+      expect(setPri).toBeDefined();
+      expect((setPri!.payload as { priority: number }).priority).toBe(9);
+    });
+
+    it("priority mode: explicit cross-section priority accepted", async () => {
+      // Same fixture style. Agent wants explicit priority 9 (inside target zone).
+      // OLD behavior: broker rejected with [0..nonSep] cap. NEW behavior: accepts.
+      const root = await mkdtemp(join(tmpdir(), "mo2-bb84-explicit-"));
+      await mkdir(join(root, "profiles", "Default"), { recursive: true });
+      const modlistLines = [
+        "+TopSep_separator",
+        "+ZoneMod1",
+        "+ZoneMod2",
+        "+TargetSep_separator",
+        "+BelowMod1",
+        "+MidSep_separator",
+        "+BelowMod2",
+        "+BelowMod3",
+        "+BottomSep_separator",
+        "+SourceMod",
+        "+BelowMod4",
+        "+BelowMod5",
+      ];
+      await writeFile(
+        join(root, "profiles", "Default", "modlist.txt"),
+        modlistLines.join("\n") + "\n",
+        "utf8",
+      );
+      await writeFile(join(root, "profiles", "Default", "plugins.txt"), "", "utf8");
+      await writeFile(
+        join(root, "ModOrganizer.ini"),
+        "[General]\ngame=fallout4\n[Settings]\nbase_directory=" + root + "\n",
+        "utf8",
+      );
+      const brokerCalls: Array<{ method: string; payload: unknown }> = [];
+      const ctx: ToolContext = {
+        config: {
+          mo2Root: root,
+          permissionCeiling: "full-control",
+          allowedProfiles: ["Default"],
+          deny: [],
+          snapshotRoot: join(root, ".mo2-mcp", "snapshots"),
+          auditRoot: join(root, ".mo2-mcp", "audit"),
+        },
+        sessionId: "test",
+        plans: new PlanCache(),
+        snapshots: new SnapshotManager(join(root, ".mo2-mcp", "snapshots"), "test"),
+        audit: new AuditLogger(join(root, ".mo2-mcp", "audit"), "test"),
+      };
+      ctx.pipeClient = {
+        call: async (method: string, payload: unknown) => {
+          brokerCalls.push({ method, payload });
+          if (method === "profile.active")
+            return { ok: true, result: { name: "Default" }, error: null };
+          if (method === "mods.set_priority") {
+            const p = payload as { priority: number };
+            const maxPriority = 11;
+            if (p.priority < 0 || p.priority > maxPriority) {
+              return {
+                ok: false,
+                error: { code: "priority_out_of_range", message: `priority ${p.priority} out of [0..${maxPriority}]` },
+              };
+            }
+            return { ok: true, result: { actual_priority: p.priority }, error: null };
+          }
+          throw new Error(`unexpected broker method ${method}`);
+        },
+        close: () => {},
+        discoverAndConnect: async () => {},
+        isConnected: () => true,
+      } as unknown as ToolContext["pipeClient"];
+      const tool = getTool("mo2_send_mod_to")!;
+      const planRes = (await tool.handler(
+        { mode: "plan", name: "SourceMod", target_mode: "priority", target_priority: 9 },
+        ctx,
+      )) as { ok: boolean; result: { plan_id: string; lease_token: string } };
+      expect(planRes.ok).toBe(true);
+      const applyRes = (await tool.handler(
+        { mode: "apply", plan_id: planRes.result.plan_id, lease_token: planRes.result.lease_token },
+        ctx,
+      )) as { ok: boolean; error?: { message: string } };
+      expect(applyRes.ok, applyRes.error?.message ?? "").toBe(true);
+      const setPri = brokerCalls.find((c) => c.method === "mods.set_priority");
+      expect((setPri!.payload as { priority: number }).priority).toBe(9);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes mo2_send_mod_to placing mods in the wrong section on cross-separator moves. Closes the bug filed at `docs/issues/BUG-mo2-mcp-send_mod_to-semantics-2026-06-27.md`.

## Root cause (two compounding bugs)

1. **Broker validator was wrong**: `_handle_mods_set_priority` capped at `len(non_separator_mods)` (e.g. 377 for BB84's 407-mod profile). mobase `IModList.setPriority` actually operates in FULL priority space — `Profile::setModPriority` clamps to `[0, m_NumRegularMods - 1]` where separators count.
2. **TS handler compensated wrongly**: issue #14 BUG-B fix added `nonSepRank()` conversion based on the wrong premise that broker space ≠ full space. This sent `setPriority(name, 348)` when the agent meant priority 378 — mobase placed the mod 30 slots too low.

Combined effect: `above_separator: 观望_separator` (priority 377) landed the mod in the `My Mods` area (priority 348), 3 separators below the intended target.

## Fix

- Broker validator: `max_priority = len(allMods) - 1` (separators included)
- TS `_computeTargetPriority`: removed `nonSepRank`; passes FULL priorities directly:
  - `above_separator` → `sep.priority + 1`
  - `above_first_conflict` → `max(conflict_pris) + 1`
  - `below_last_conflict` → `min(conflict_pris) - 1`
  - `priority` → clamp to `[0, mod_count - 1]`

## Substrate verification (from MO2 source recon)

- `IModList.setPriority` signature: accepts `priority` in FULL space, returns `True` if changed
- `Profile::setModPriority`: `std::clamp(newPriority, 0, m_NumRegularMods - 1)`
- `PluginState` enum has 3 values (MISSING / INACTIVE / ACTIVE) — no PROBLEMATIC
- modlist.txt = REVERSED priority order (file top = priority N-1 = wins)
- plugins.txt = FORWARD load order (file bottom = loaded last = wins)
- MO2 GUI shows both panels with BOTTOM = wins (mods + plugins agree visually, files differ)

## Tests

- **pytest**: 31 passed (added 2 regression tests for separator-counts-in-validator + cross-section accept)
- **vitest**: 538 passed / 19 skipped (added 2 regression tests mirroring BB84's 12-mod / 4-separator pattern)
- `npm run build`: exit 0

## Commits

| SHA | What |
|---|---|
| 27be593 | fix(broker): mods.set_priority validator uses full priority space |
| 1138ea5 | fix(mo2-mcp): send_mod_to uses full priority space, reverts nonSepRank |
| ecc0e42 | chore(plugin-pack): mirror send_mod_to fix into plugins/ tree |

## Live acceptance plan (post-merge)

Real BB84 fixture (407 mods, 30 separators). Will move a low-priority mod above 版本已过期_separator (priority 394) via:
1. `mo2_send_mod_to above_separator: 版本已过期_separator` → expect `priority 395` in diff + broker accepts
2. Readback via `mo2_modlist` shows mod at priority 395

Broker redeploy required (per memory rule 9). Restart MO2.