### PR TITLE
fix(broker): auto-refresh MO2 GUI after every mutating handler

### DIFF
--- a/plugins/bgs-modding-superpowers/tools/mo2-control-plane/live-bridge/mo2_agent_control.py
+++ b/plugins/bgs-modding-superpowers/tools/mo2-control-plane/live-bridge/mo2_agent_control.py
@@ -941,11 +941,18 @@ def _handle_mods_set_active(organizer, pump, payload):
                 readback.append({"name": name, "active": None})
                 failed.append(name)
 
+        try:
+            organizer.refresh()
+            refreshed = True
+        except Exception:
+            refreshed = False
+
         return {
             "requested": list(names),
             "applied": applied,
             "failed": failed,
             "readback": readback,
+            "gui_refreshed": refreshed,
         }
 
     try:
@@ -1007,6 +1014,11 @@ def _handle_mods_set_priority(organizer, pump, payload):
         before = mod_list.priority(name)
         mod_list.setPriority(name, priority)
         actual = mod_list.priority(name)
+        try:
+            organizer.refresh()
+            refreshed = True
+        except Exception:
+            refreshed = False
         return (
             "ok",
             {
@@ -1014,6 +1026,7 @@ def _handle_mods_set_priority(organizer, pump, payload):
                 "requested_priority": priority,
                 "actual_priority": actual,
                 "noop": (actual == before) and (before != priority),
+                "gui_refreshed": refreshed,
             },
         )
 
@@ -1080,12 +1093,18 @@ def _handle_mods_rename(organizer, pump, payload):
             return ("error", ErrorCode.INVALID_PARAMS, f"name '{sanitized_name}' already exists")
 
         refreshed = mod_list.renameMod(mod, sanitized_name)
+        try:
+            organizer.refresh()
+            gui_refreshed = True
+        except Exception:
+            gui_refreshed = False
         return (
             "ok",
             {
                 "old_name": old_name,
                 "new_name": refreshed.name() if refreshed is not None else sanitized_name,
                 "name_was_sanitized": sanitized_name != new_name,
+                "gui_refreshed": gui_refreshed,
             },
         )
 
@@ -1133,7 +1152,13 @@ def _handle_mods_remove(organizer, pump, payload):
         if not removed:
             return ("error", ErrorCode.INTERNAL_ERROR, "removeMod returned False")
 
-        return ("ok", {"name": name, "removed": True})
+        try:
+            organizer.refresh()
+            refreshed = True
+        except Exception:
+            refreshed = False
+
+        return ("ok", {"name": name, "removed": True, "gui_refreshed": refreshed})
 
     try:
         outcome = pump.invoke_blocking(_on_main_thread, timeout_s=30)
@@ -1378,7 +1403,16 @@ def _handle_mods_meta_write(organizer, pump, payload):
 
     updated_sections = list(updates.keys())
     try:
-        pump.invoke_blocking(lambda: organizer.modDataChanged(mod), timeout_s=5)
+        def _notify_and_refresh():
+            organizer.modDataChanged(mod)
+            try:
+                organizer.refresh()
+                refreshed = True
+            except Exception:
+                refreshed = False
+            return refreshed
+
+        gui_refreshed = pump.invoke_blocking(_notify_and_refresh, timeout_s=5)
     except Exception as exc:
         return {
             "ok": True,
@@ -1386,13 +1420,14 @@ def _handle_mods_meta_write(organizer, pump, payload):
                 "name": name,
                 "updated_sections": updated_sections,
                 "notification_skipped": str(exc),
+                "gui_refreshed": False,
             },
             "error": None,
         }
 
     return {
         "ok": True,
-        "result": {"name": name, "updated_sections": updated_sections},
+        "result": {"name": name, "updated_sections": updated_sections, "gui_refreshed": gui_refreshed},
         "error": None,
     }
 
@@ -1446,12 +1481,18 @@ def _handle_plugins_set_state(organizer, pump, payload):
         if name not in plugin_list.pluginNames():
             return ("error", ErrorCode.PLUGIN_NOT_FOUND, name)
         plugin_list.setState(name, state)
+        try:
+            organizer.refresh()
+            refreshed = True
+        except Exception:
+            refreshed = False
         return (
             "ok",
             {
                 "name": name,
                 "requested_state": state,
                 "actual_state": int(plugin_list.state(name)),
+                "gui_refreshed": refreshed,
             },
         )
 
@@ -1498,6 +1539,11 @@ def _handle_plugins_set_priority(organizer, pump, payload):
         before = plugin_list.priority(name)
         plugin_list.setPriority(name, priority)
         after = plugin_list.priority(name)
+        try:
+            organizer.refresh()
+            refreshed = True
+        except Exception:
+            refreshed = False
         return (
             "ok",
             {
@@ -1505,6 +1551,7 @@ def _handle_plugins_set_priority(organizer, pump, payload):
                 "requested_priority": priority,
                 "actual_priority": after,
                 "noop": after == before and before != priority,
+                "gui_refreshed": refreshed,
             },
         )
 
@@ -1546,12 +1593,18 @@ def _handle_plugins_set_load_order(organizer, pump, payload):
 
         plugin_list.setLoadOrder(order)
         effective = sorted(plugin_list.pluginNames(), key=lambda name: plugin_list.priority(name))
+        try:
+            organizer.refresh()
+            refreshed = True
+        except Exception:
+            refreshed = False
         return (
             "ok",
             {
                 "requested_explicit": list(order),
                 "effective_order": effective,
                 "implicitly_appended_count": len(effective) - len(order),
+                "gui_refreshed": refreshed,
             },
         )
 

--- a/plugins/bgs-modding-superpowers/tools/mo2-control-plane/live-bridge/tests/test_broker_mods_commands.py
+++ b/plugins/bgs-modding-superpowers/tools/mo2-control-plane/live-bridge/tests/test_broker_mods_commands.py
@@ -100,6 +100,8 @@ def test_mods_set_active_single_with_readback(monkeypatch):
     assert readback["applied"] == ["ModA"]
     assert readback["failed"] == []
     assert readback["readback"] == [{"name": "ModA", "active": True}]
+    assert readback["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_mods_set_active_partial_failure(monkeypatch):
@@ -129,6 +131,8 @@ def test_mods_set_active_partial_failure(monkeypatch):
     assert readback["readback"][0]["active"] is True
     assert readback["readback"][1]["name"] == "ModB"
     assert readback["readback"][1]["active"] is False
+    assert readback["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_mods_set_active_invalid_params_returns_error(monkeypatch):
@@ -185,6 +189,8 @@ def test_mods_set_priority_success(monkeypatch):
     assert readback["requested_priority"] == 1
     assert readback["actual_priority"] == 1
     assert readback["noop"] is False
+    assert readback["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_mods_set_priority_silent_noop_detected(monkeypatch):
@@ -208,6 +214,8 @@ def test_mods_set_priority_silent_noop_detected(monkeypatch):
     readback = result["result"]
     assert readback["actual_priority"] == 0
     assert readback["noop"] is True
+    assert readback["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_mods_set_priority_mod_not_found(monkeypatch):
@@ -224,6 +232,7 @@ def test_mods_set_priority_mod_not_found(monkeypatch):
 
     assert result["ok"] is False
     assert result["error"]["code"] == "mod_not_found"
+    organizer.refresh.assert_not_called()
 
 
 def test_mods_set_priority_out_of_range(monkeypatch):
@@ -296,6 +305,8 @@ def test_mods_set_priority_separators_count_in_validator(monkeypatch):
     assert result["ok"] is True, f"separator slot rejected: {result.get('error')}"
     assert result["result"]["requested_priority"] == 3
     assert result["result"]["actual_priority"] == 3
+    assert result["result"]["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_mods_rename_success(monkeypatch):
@@ -319,6 +330,8 @@ def test_mods_rename_success(monkeypatch):
     assert readback["old_name"] == "OldName"
     assert readback["new_name"] == "NewName"
     assert readback["name_was_sanitized"] is False
+    assert readback["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_mods_rename_sanitizes_illegal_chars(monkeypatch):
@@ -349,7 +362,9 @@ def test_mods_rename_sanitizes_illegal_chars(monkeypatch):
     assert result["ok"] is True
     assert result["result"]["new_name"] == "BadName"
     assert result["result"]["name_was_sanitized"] is True
+    assert result["result"]["gui_refreshed"] is True
     mod_list.renameMod.assert_called_once_with(old_mod, "BadName")
+    organizer.refresh.assert_called_once_with()
 
 
 def test_mods_rename_not_found_returns_error(monkeypatch):
@@ -366,6 +381,7 @@ def test_mods_rename_not_found_returns_error(monkeypatch):
 
     assert result["ok"] is False
     assert result["error"]["code"] == "mod_not_found"
+    organizer.refresh.assert_not_called()
 
 
 def test_mods_rename_collision_returns_error(monkeypatch):
@@ -415,7 +431,9 @@ def test_mods_remove_success(monkeypatch):
     assert result["ok"] is True
     assert result["result"]["name"] == "ModA"
     assert result["result"]["removed"] is True
+    assert result["result"]["gui_refreshed"] is True
     mod_list.removeMod.assert_called_once_with(mod)
+    organizer.refresh.assert_called_once_with()
 
 
 def test_mods_remove_not_found(monkeypatch):
@@ -433,6 +451,7 @@ def test_mods_remove_not_found(monkeypatch):
     assert result["ok"] is False
     assert result["error"]["code"] == "mod_not_found"
     mod_list.removeMod.assert_not_called()
+    organizer.refresh.assert_not_called()
 
 
 def test_mods_remove_failure_from_modlist(monkeypatch):
@@ -451,6 +470,7 @@ def test_mods_remove_failure_from_modlist(monkeypatch):
 
     assert result["ok"] is False
     assert result["error"]["code"] == "internal_error"
+    organizer.refresh.assert_not_called()
 
 
 def test_mods_create_basic(monkeypatch, tmp_path):
@@ -668,7 +688,9 @@ def test_mods_meta_write_creates_meta_ini(monkeypatch, tmp_path):
     assert result["ok"] is True
     assert result["result"]["name"] == "ModA"
     assert "General" in result["result"]["updated_sections"]
+    assert result["result"]["gui_refreshed"] is True
     organizer.modDataChanged.assert_called_once_with(mod)
+    organizer.refresh.assert_called_once_with()
 
     parser = configparser.ConfigParser(interpolation=None)
     parser.read(mod_dir / "meta.ini", encoding="utf-8")
@@ -702,6 +724,8 @@ def test_mods_meta_write_merges_existing(monkeypatch, tmp_path):
     )
 
     assert result["ok"] is True
+    assert result["result"]["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
     parser = configparser.ConfigParser(interpolation=None)
     parser.read(mod_dir / "meta.ini", encoding="utf-8")
     assert parser["General"]["version"] == "2.0"
@@ -739,6 +763,7 @@ def test_mods_meta_write_mod_not_found(monkeypatch):
     )
     assert result["ok"] is False
     assert result["error"]["code"] == "mod_not_found"
+    organizer.refresh.assert_not_called()
 
 
 def test_mods_meta_write_atomic_no_leftover_tmp(monkeypatch, tmp_path):
@@ -764,5 +789,7 @@ def test_mods_meta_write_atomic_no_leftover_tmp(monkeypatch, tmp_path):
     )
 
     assert result["ok"] is True
+    assert result["result"]["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
     leftovers = list(mod_dir.glob(".tmp-*"))
     assert leftovers == []

--- a/plugins/bgs-modding-superpowers/tools/mo2-control-plane/live-bridge/tests/test_broker_plugins_commands.py
+++ b/plugins/bgs-modding-superpowers/tools/mo2-control-plane/live-bridge/tests/test_broker_plugins_commands.py
@@ -141,6 +141,8 @@ def test_plugins_set_state_success(monkeypatch):
     assert readback["name"] == "ModA.esp"
     assert readback["requested_state"] == 2
     assert readback["actual_state"] == 2
+    assert readback["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_plugins_set_state_plugin_not_found(monkeypatch):
@@ -157,6 +159,7 @@ def test_plugins_set_state_plugin_not_found(monkeypatch):
 
     assert result["ok"] is False
     assert result["error"]["code"] == "plugin_not_found"
+    organizer.refresh.assert_not_called()
 
 
 def test_plugins_set_state_invalid_params(monkeypatch):
@@ -197,6 +200,8 @@ def test_plugins_set_priority_success(monkeypatch):
     assert readback["name"] == "B.esp"
     assert readback["actual_priority"] == 1
     assert readback["noop"] is False
+    assert readback["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_plugins_set_priority_silent_noop_detected(monkeypatch):
@@ -218,6 +223,8 @@ def test_plugins_set_priority_silent_noop_detected(monkeypatch):
 
     assert result["ok"] is True
     assert result["result"]["noop"] is True
+    assert result["result"]["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_plugins_set_priority_plugin_not_found(monkeypatch):
@@ -238,6 +245,7 @@ def test_plugins_set_priority_plugin_not_found(monkeypatch):
 
     assert result["ok"] is False
     assert result["error"]["code"] == "plugin_not_found"
+    organizer.refresh.assert_not_called()
 
 
 def test_plugins_set_load_order_success(monkeypatch):
@@ -267,6 +275,8 @@ def test_plugins_set_load_order_success(monkeypatch):
     assert readback["requested_explicit"] == ["B.esp", "A.esp"]
     assert readback["effective_order"][:2] == ["B.esp", "A.esp"]
     assert readback["implicitly_appended_count"] == 1
+    assert readback["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_plugins_set_load_order_unknown_plugin_rejected(monkeypatch):
@@ -287,6 +297,7 @@ def test_plugins_set_load_order_unknown_plugin_rejected(monkeypatch):
 
     assert result["ok"] is False
     assert result["error"]["code"] == "plugin_not_found"
+    organizer.refresh.assert_not_called()
 
 
 def test_plugins_set_load_order_invalid_params(monkeypatch):

--- a/tools/mo2-control-plane/live-bridge/mo2_agent_control.py
+++ b/tools/mo2-control-plane/live-bridge/mo2_agent_control.py
@@ -941,11 +941,18 @@ def _handle_mods_set_active(organizer, pump, payload):
                 readback.append({"name": name, "active": None})
                 failed.append(name)
 
+        try:
+            organizer.refresh()
+            refreshed = True
+        except Exception:
+            refreshed = False
+
         return {
             "requested": list(names),
             "applied": applied,
             "failed": failed,
             "readback": readback,
+            "gui_refreshed": refreshed,
         }
 
     try:
@@ -1007,6 +1014,11 @@ def _handle_mods_set_priority(organizer, pump, payload):
         before = mod_list.priority(name)
         mod_list.setPriority(name, priority)
         actual = mod_list.priority(name)
+        try:
+            organizer.refresh()
+            refreshed = True
+        except Exception:
+            refreshed = False
         return (
             "ok",
             {
@@ -1014,6 +1026,7 @@ def _handle_mods_set_priority(organizer, pump, payload):
                 "requested_priority": priority,
                 "actual_priority": actual,
                 "noop": (actual == before) and (before != priority),
+                "gui_refreshed": refreshed,
             },
         )
 
@@ -1080,12 +1093,18 @@ def _handle_mods_rename(organizer, pump, payload):
             return ("error", ErrorCode.INVALID_PARAMS, f"name '{sanitized_name}' already exists")
 
         refreshed = mod_list.renameMod(mod, sanitized_name)
+        try:
+            organizer.refresh()
+            gui_refreshed = True
+        except Exception:
+            gui_refreshed = False
         return (
             "ok",
             {
                 "old_name": old_name,
                 "new_name": refreshed.name() if refreshed is not None else sanitized_name,
                 "name_was_sanitized": sanitized_name != new_name,
+                "gui_refreshed": gui_refreshed,
             },
         )
 
@@ -1133,7 +1152,13 @@ def _handle_mods_remove(organizer, pump, payload):
         if not removed:
             return ("error", ErrorCode.INTERNAL_ERROR, "removeMod returned False")
 
-        return ("ok", {"name": name, "removed": True})
+        try:
+            organizer.refresh()
+            refreshed = True
+        except Exception:
+            refreshed = False
+
+        return ("ok", {"name": name, "removed": True, "gui_refreshed": refreshed})
 
     try:
         outcome = pump.invoke_blocking(_on_main_thread, timeout_s=30)
@@ -1378,7 +1403,16 @@ def _handle_mods_meta_write(organizer, pump, payload):
 
     updated_sections = list(updates.keys())
     try:
-        pump.invoke_blocking(lambda: organizer.modDataChanged(mod), timeout_s=5)
+        def _notify_and_refresh():
+            organizer.modDataChanged(mod)
+            try:
+                organizer.refresh()
+                refreshed = True
+            except Exception:
+                refreshed = False
+            return refreshed
+
+        gui_refreshed = pump.invoke_blocking(_notify_and_refresh, timeout_s=5)
     except Exception as exc:
         return {
             "ok": True,
@@ -1386,13 +1420,14 @@ def _handle_mods_meta_write(organizer, pump, payload):
                 "name": name,
                 "updated_sections": updated_sections,
                 "notification_skipped": str(exc),
+                "gui_refreshed": False,
             },
             "error": None,
         }
 
     return {
         "ok": True,
-        "result": {"name": name, "updated_sections": updated_sections},
+        "result": {"name": name, "updated_sections": updated_sections, "gui_refreshed": gui_refreshed},
         "error": None,
     }
 
@@ -1446,12 +1481,18 @@ def _handle_plugins_set_state(organizer, pump, payload):
         if name not in plugin_list.pluginNames():
             return ("error", ErrorCode.PLUGIN_NOT_FOUND, name)
         plugin_list.setState(name, state)
+        try:
+            organizer.refresh()
+            refreshed = True
+        except Exception:
+            refreshed = False
         return (
             "ok",
             {
                 "name": name,
                 "requested_state": state,
                 "actual_state": int(plugin_list.state(name)),
+                "gui_refreshed": refreshed,
             },
         )
 
@@ -1498,6 +1539,11 @@ def _handle_plugins_set_priority(organizer, pump, payload):
         before = plugin_list.priority(name)
         plugin_list.setPriority(name, priority)
         after = plugin_list.priority(name)
+        try:
+            organizer.refresh()
+            refreshed = True
+        except Exception:
+            refreshed = False
         return (
             "ok",
             {
@@ -1505,6 +1551,7 @@ def _handle_plugins_set_priority(organizer, pump, payload):
                 "requested_priority": priority,
                 "actual_priority": after,
                 "noop": after == before and before != priority,
+                "gui_refreshed": refreshed,
             },
         )
 
@@ -1546,12 +1593,18 @@ def _handle_plugins_set_load_order(organizer, pump, payload):
 
         plugin_list.setLoadOrder(order)
         effective = sorted(plugin_list.pluginNames(), key=lambda name: plugin_list.priority(name))
+        try:
+            organizer.refresh()
+            refreshed = True
+        except Exception:
+            refreshed = False
         return (
             "ok",
             {
                 "requested_explicit": list(order),
                 "effective_order": effective,
                 "implicitly_appended_count": len(effective) - len(order),
+                "gui_refreshed": refreshed,
             },
         )
 

--- a/tools/mo2-control-plane/live-bridge/tests/test_broker_mods_commands.py
+++ b/tools/mo2-control-plane/live-bridge/tests/test_broker_mods_commands.py
@@ -100,6 +100,8 @@ def test_mods_set_active_single_with_readback(monkeypatch):
     assert readback["applied"] == ["ModA"]
     assert readback["failed"] == []
     assert readback["readback"] == [{"name": "ModA", "active": True}]
+    assert readback["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_mods_set_active_partial_failure(monkeypatch):
@@ -129,6 +131,8 @@ def test_mods_set_active_partial_failure(monkeypatch):
     assert readback["readback"][0]["active"] is True
     assert readback["readback"][1]["name"] == "ModB"
     assert readback["readback"][1]["active"] is False
+    assert readback["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_mods_set_active_invalid_params_returns_error(monkeypatch):
@@ -185,6 +189,8 @@ def test_mods_set_priority_success(monkeypatch):
     assert readback["requested_priority"] == 1
     assert readback["actual_priority"] == 1
     assert readback["noop"] is False
+    assert readback["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_mods_set_priority_silent_noop_detected(monkeypatch):
@@ -208,6 +214,8 @@ def test_mods_set_priority_silent_noop_detected(monkeypatch):
     readback = result["result"]
     assert readback["actual_priority"] == 0
     assert readback["noop"] is True
+    assert readback["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_mods_set_priority_mod_not_found(monkeypatch):
@@ -224,6 +232,7 @@ def test_mods_set_priority_mod_not_found(monkeypatch):
 
     assert result["ok"] is False
     assert result["error"]["code"] == "mod_not_found"
+    organizer.refresh.assert_not_called()
 
 
 def test_mods_set_priority_out_of_range(monkeypatch):
@@ -296,6 +305,8 @@ def test_mods_set_priority_separators_count_in_validator(monkeypatch):
     assert result["ok"] is True, f"separator slot rejected: {result.get('error')}"
     assert result["result"]["requested_priority"] == 3
     assert result["result"]["actual_priority"] == 3
+    assert result["result"]["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_mods_rename_success(monkeypatch):
@@ -319,6 +330,8 @@ def test_mods_rename_success(monkeypatch):
     assert readback["old_name"] == "OldName"
     assert readback["new_name"] == "NewName"
     assert readback["name_was_sanitized"] is False
+    assert readback["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_mods_rename_sanitizes_illegal_chars(monkeypatch):
@@ -349,7 +362,9 @@ def test_mods_rename_sanitizes_illegal_chars(monkeypatch):
     assert result["ok"] is True
     assert result["result"]["new_name"] == "BadName"
     assert result["result"]["name_was_sanitized"] is True
+    assert result["result"]["gui_refreshed"] is True
     mod_list.renameMod.assert_called_once_with(old_mod, "BadName")
+    organizer.refresh.assert_called_once_with()
 
 
 def test_mods_rename_not_found_returns_error(monkeypatch):
@@ -366,6 +381,7 @@ def test_mods_rename_not_found_returns_error(monkeypatch):
 
     assert result["ok"] is False
     assert result["error"]["code"] == "mod_not_found"
+    organizer.refresh.assert_not_called()
 
 
 def test_mods_rename_collision_returns_error(monkeypatch):
@@ -415,7 +431,9 @@ def test_mods_remove_success(monkeypatch):
     assert result["ok"] is True
     assert result["result"]["name"] == "ModA"
     assert result["result"]["removed"] is True
+    assert result["result"]["gui_refreshed"] is True
     mod_list.removeMod.assert_called_once_with(mod)
+    organizer.refresh.assert_called_once_with()
 
 
 def test_mods_remove_not_found(monkeypatch):
@@ -433,6 +451,7 @@ def test_mods_remove_not_found(monkeypatch):
     assert result["ok"] is False
     assert result["error"]["code"] == "mod_not_found"
     mod_list.removeMod.assert_not_called()
+    organizer.refresh.assert_not_called()
 
 
 def test_mods_remove_failure_from_modlist(monkeypatch):
@@ -451,6 +470,7 @@ def test_mods_remove_failure_from_modlist(monkeypatch):
 
     assert result["ok"] is False
     assert result["error"]["code"] == "internal_error"
+    organizer.refresh.assert_not_called()
 
 
 def test_mods_create_basic(monkeypatch, tmp_path):
@@ -668,7 +688,9 @@ def test_mods_meta_write_creates_meta_ini(monkeypatch, tmp_path):
     assert result["ok"] is True
     assert result["result"]["name"] == "ModA"
     assert "General" in result["result"]["updated_sections"]
+    assert result["result"]["gui_refreshed"] is True
     organizer.modDataChanged.assert_called_once_with(mod)
+    organizer.refresh.assert_called_once_with()
 
     parser = configparser.ConfigParser(interpolation=None)
     parser.read(mod_dir / "meta.ini", encoding="utf-8")
@@ -702,6 +724,8 @@ def test_mods_meta_write_merges_existing(monkeypatch, tmp_path):
     )
 
     assert result["ok"] is True
+    assert result["result"]["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
     parser = configparser.ConfigParser(interpolation=None)
     parser.read(mod_dir / "meta.ini", encoding="utf-8")
     assert parser["General"]["version"] == "2.0"
@@ -739,6 +763,7 @@ def test_mods_meta_write_mod_not_found(monkeypatch):
     )
     assert result["ok"] is False
     assert result["error"]["code"] == "mod_not_found"
+    organizer.refresh.assert_not_called()
 
 
 def test_mods_meta_write_atomic_no_leftover_tmp(monkeypatch, tmp_path):
@@ -764,5 +789,7 @@ def test_mods_meta_write_atomic_no_leftover_tmp(monkeypatch, tmp_path):
     )
 
     assert result["ok"] is True
+    assert result["result"]["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
     leftovers = list(mod_dir.glob(".tmp-*"))
     assert leftovers == []

--- a/tools/mo2-control-plane/live-bridge/tests/test_broker_plugins_commands.py
+++ b/tools/mo2-control-plane/live-bridge/tests/test_broker_plugins_commands.py
@@ -141,6 +141,8 @@ def test_plugins_set_state_success(monkeypatch):
     assert readback["name"] == "ModA.esp"
     assert readback["requested_state"] == 2
     assert readback["actual_state"] == 2
+    assert readback["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_plugins_set_state_plugin_not_found(monkeypatch):
@@ -157,6 +159,7 @@ def test_plugins_set_state_plugin_not_found(monkeypatch):
 
     assert result["ok"] is False
     assert result["error"]["code"] == "plugin_not_found"
+    organizer.refresh.assert_not_called()
 
 
 def test_plugins_set_state_invalid_params(monkeypatch):
@@ -197,6 +200,8 @@ def test_plugins_set_priority_success(monkeypatch):
     assert readback["name"] == "B.esp"
     assert readback["actual_priority"] == 1
     assert readback["noop"] is False
+    assert readback["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_plugins_set_priority_silent_noop_detected(monkeypatch):
@@ -218,6 +223,8 @@ def test_plugins_set_priority_silent_noop_detected(monkeypatch):
 
     assert result["ok"] is True
     assert result["result"]["noop"] is True
+    assert result["result"]["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_plugins_set_priority_plugin_not_found(monkeypatch):
@@ -238,6 +245,7 @@ def test_plugins_set_priority_plugin_not_found(monkeypatch):
 
     assert result["ok"] is False
     assert result["error"]["code"] == "plugin_not_found"
+    organizer.refresh.assert_not_called()
 
 
 def test_plugins_set_load_order_success(monkeypatch):
@@ -267,6 +275,8 @@ def test_plugins_set_load_order_success(monkeypatch):
     assert readback["requested_explicit"] == ["B.esp", "A.esp"]
     assert readback["effective_order"][:2] == ["B.esp", "A.esp"]
     assert readback["implicitly_appended_count"] == 1
+    assert readback["gui_refreshed"] is True
+    organizer.refresh.assert_called_once_with()
 
 
 def test_plugins_set_load_order_unknown_plugin_rejected(monkeypatch):
@@ -287,6 +297,7 @@ def test_plugins_set_load_order_unknown_plugin_rejected(monkeypatch):
 
     assert result["ok"] is False
     assert result["error"]["code"] == "plugin_not_found"
+    organizer.refresh.assert_not_called()
 
 
 def test_plugins_set_load_order_invalid_params(monkeypatch):


### PR DESCRIPTION
## Summary

After mutation, MO2 GUI shows stale state until the user clicks refresh manually. User-friendly fix: broker now calls `organizer.refresh()` at the end of every mutating handler's main-thread closure.

Filed as followup after PR #18 live acceptance — user observed that `mo2_send_mod_to` apply succeeds with correct priority, but the MO2 mods panel still shows old position until F5.

## Root cause

8 of 11 mutating broker handlers were missing `organizer.refresh()`. The fix adds it INSIDE the same `pump.invoke_blocking` closure as the mutation (per memory rule 1; outside-closure refresh corrupts modlist with "invalid mod index" — BUG-2 lesson).

## Handlers fixed

- `mods.set_priority`
- `mods.set_active`
- `plugins.set_state`
- `plugins.set_priority`
- `plugins.set_load_order`
- `mods.remove`
- `mods.rename`
- `mods.meta_write`

Handlers that already had refresh (unchanged): `mods.create`, `installation.create_mod_from_directory`, `installation.install_local_archive`.

## Response envelope

All 8 modified handlers now return `gui_refreshed: bool` so agents can confirm the refresh actually happened. `False` only if refresh itself threw (very rare; mutation already succeeded).

## Tests

- pytest: 43 passed (31 mod + 12 plugin), covering both success and "no refresh on error" paths
- TS layer unchanged (no rebuild needed)

## Live acceptance plan

Broker redeploy required (per memory rule 9). After redeploy + MO2 restart:
1. `mo2_send_mod_to` apply on a real mod
2. Observe: MO2 GUI mods panel reflects the new position WITHOUT manual F5 click
3. `mo2_toggle_mod` apply
4. Observe: enable/disable state reflects WITHOUT manual refresh

## Risks

- `organizer.refresh()` with default `save_changes=True` writes the profile to disk. If the user has pending unsaved changes elsewhere, those get persisted earlier than they might have expected. Mitigation: this matches existing behavior of `mods.create` etc.
- Refresh has a small latency cost per mutation. For batch operations (many sequential mutations), this could add up. Acceptable trade-off for the agent + user experience win.