### PR TITLE
fix(mo2-mcp): mo2_send_plugin_to uses mobase priority space in live mode (closes #20)

### DIFF
--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/tools/mo2-send-plugin-to.js
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/dist/tools/mo2-send-plugin-to.js
@@ -1,12 +1,26 @@
 /**
  * mo2_send_plugin_to — T3 reposition a plugin by GUI-aligned target mode.
  *
- * plugins.txt is FORWARD order and matches the MO2 GUI plugins pane:
- *   - gui_top              → priority 0 (loaded first, loses all plugin conflicts)
- *   - gui_bottom           → priority N-1 (loaded last, wins all plugin conflicts)
+ * Two priority spaces:
+ *
+ * - LIVE (broker present): mobase `IPluginList::setPriority` operates in the
+ *   FULL plugin-priority space, which interleaves foreign-managed officials
+ *   (e.g., Starfield's 12 official masters at priorities 0..11) with the user-
+ *   controllable plugins. The broker is authoritative; this tool queries
+ *   `plugins.list` and computes targets against the real mobase priorities.
+ *   To keep the user-facing semantics intuitive, the target search is filtered
+ *   to plugins.txt entries (foreign officials are not addressable as anchors
+ *   and do not pin `gui_top`/`gui_bottom`).
+ *
+ * - OFFLINE (no broker): the tool rewrites plugins.txt directly. Priority is
+ *   the 0-based forward-index within plugins.txt (after the comment header).
+ *
+ * Vocabulary contract (mirrors MO2 GUI plugins panel — BOTTOM wins):
+ *   - gui_top              → priority of the FIRST plugins.txt entry (loaded first, loses all)
+ *   - gui_bottom           → priority of the LAST plugins.txt entry (loaded last, wins all)
  *   - wins_over <anchor>   → anchor.priority + 1
  *   - loses_to <anchor>    → anchor.priority - 1
- *   - raw_priority         → explicit plugins.txt priority, clamped [0, N-1]
+ *   - raw_priority         → explicit mobase priority (live) / plugins.txt index (offline), clamped
  */
 import { z } from "zod";
 import { readFile } from "node:fs/promises";
@@ -36,12 +50,44 @@ const inputSchema = z.discriminatedUnion("mode", [
     }).strict(),
     z.object({ mode: z.literal("apply"), plan_id: z.string().min(1), lease_token: z.string().min(1) }).strict(),
 ]);
-const RESPONSE_META = {
+const RESPONSE_META_BROKER = {
+    priority_convention: "mobase_full_space_higher_wins",
+    plugins_txt_file_order: "forward_matches_gui",
+    gui_direction_hint: "priority is mobase IPluginList space; foreign officials occupy a leading prefix; higher_priority_wins",
+    priority_space: "mobase",
+};
+const RESPONSE_META_OFFLINE = {
     priority_convention: "plugins_txt_forward_space_higher_wins",
     plugins_txt_file_order: "forward_matches_gui",
     gui_direction_hint: "priority_0_at_gui_top_loads_first_loses; priority_(N-1)_at_gui_bottom_loads_last_wins",
+    priority_space: "plugins_txt_index",
 };
-async function _pluginPriorities(ctx, profile) {
+/**
+ * LIVE-mode priority view. Filters broker's full plugin list down to the
+ * plugins.txt entries (foreign officials excluded) so user-facing min/max
+ * and anchor lookups match what the curator sees in the GUI panel.
+ */
+async function _pluginPrioritiesFromBroker(ctx, profile) {
+    const bound = requireBoundContext(ctx);
+    if (!bound.pipeClient)
+        throw new Error("broker_required_for_live_priority_view");
+    const resp = await bound.pipeClient.call("plugins.list", {});
+    if (!resp.ok)
+        throw new Error(resp.error?.message ?? "plugins.list failed");
+    const result = resp.result ?? {};
+    const list = result.plugins ?? [];
+    const profileData = await readProfile(join(bound.config.mo2Root, "profiles", profile));
+    const inPluginsTxt = new Set(profileData.plugins.filter((p) => !p.isComment).map((p) => p.name));
+    return list
+        .filter((p) => inPluginsTxt.has(p.name))
+        .filter((p) => typeof p.priority === "number")
+        .map((p) => ({ name: p.name, priority: p.priority }));
+}
+/**
+ * OFFLINE-mode priority view. Assigns sequential 0-based indices over the
+ * plugins.txt entries (after the comment header).
+ */
+async function _pluginPrioritiesFromFile(ctx, profile) {
     const bound = requireBoundContext(ctx);
     const p = await readProfile(join(bound.config.mo2Root, "profiles", profile));
     return p.plugins
@@ -49,24 +95,33 @@ async function _pluginPriorities(ctx, profile) {
         .map((plugin, priority) => ({ name: plugin.name, priority }));
 }
 async function _computeTargetPriority(args, ctx, profile) {
-    const plugins = await _pluginPriorities(ctx, profile);
-    const maxPri = Math.max(0, plugins.length - 1);
+    const bound = requireBoundContext(ctx);
+    const useBroker = !!bound.pipeClient;
+    const plugins = useBroker
+        ? await _pluginPrioritiesFromBroker(ctx, profile)
+        : await _pluginPrioritiesFromFile(ctx, profile);
+    if (plugins.length === 0) {
+        throw new Error("no_plugins_in_profile");
+    }
+    const priorities = plugins.map((p) => p.priority);
+    const maxPri = Math.max(...priorities);
+    const minPri = Math.min(...priorities);
     const clamp = (v) => Math.max(0, Math.min(v, maxPri));
-    const source = plugins.find((plugin) => plugin.name === args.name);
+    const source = plugins.find((p) => p.name === args.name);
     if (!source)
         throw new Error(`plugin_not_found: ${String(args.name)}`);
     const mode = args.target_mode;
     switch (mode) {
         case "gui_top":
-            return 0;
+            return { priority: minPri, useBroker };
         case "gui_bottom":
-            return maxPri;
+            return { priority: maxPri, useBroker };
         case "raw_priority": {
             const tp = args.target_priority;
             if (typeof tp !== "number" || !Number.isInteger(tp)) {
                 throw new Error("raw_priority_requires_target_priority_int");
             }
-            return clamp(tp);
+            return { priority: clamp(tp), useBroker };
         }
         case "wins_over":
         case "loses_to": {
@@ -74,10 +129,13 @@ async function _computeTargetPriority(args, ctx, profile) {
             if (typeof anchorName !== "string" || anchorName.length === 0) {
                 throw new Error(`${mode}_requires_anchor`);
             }
-            const anchor = plugins.find((plugin) => plugin.name === anchorName);
+            const anchor = plugins.find((p) => p.name === anchorName);
             if (!anchor)
                 throw new Error(`anchor_not_found: ${anchorName}`);
-            return clamp(mode === "wins_over" ? anchor.priority + 1 : anchor.priority - 1);
+            return {
+                priority: clamp(mode === "wins_over" ? anchor.priority + 1 : anchor.priority - 1),
+                useBroker,
+            };
         }
         default:
             throw new Error(`unknown_mode: ${mode}`);
@@ -100,14 +158,13 @@ const handler = {
     async buildPlan(args, ctx) {
         const profile = args.profile ?? "Default";
         await assertActiveProfile(ctx, profile);
-        const targetPri = await _computeTargetPriority(args, ctx, profile);
+        const { priority: targetPri, useBroker } = await _computeTargetPriority(args, ctx, profile);
         const pluginsPath = join(resolveProfileDir(ctx, profile), "plugins.txt");
-        const p = await _pluginPriorities(ctx, profile);
-        const maxPri = Math.max(0, p.length - 1);
+        const space = useBroker ? "mobase" : "plugins_txt_index";
         const diffMeta = (() => {
             switch (args.target_mode) {
-                case "gui_top": return "gui_top (priority 0 = loads first = loses all)";
-                case "gui_bottom": return `gui_bottom (priority ${maxPri} = loads last = wins all)`;
+                case "gui_top": return `gui_top (priority ${targetPri} = loads first = loses all)`;
+                case "gui_bottom": return `gui_bottom (priority ${targetPri} = loads last = wins all)`;
                 case "wins_over": return `wins_over ${args.anchor}`;
                 case "loses_to": return `loses_to ${args.anchor}`;
                 case "raw_priority": return `raw_priority ${args.target_priority}`;
@@ -115,7 +172,7 @@ const handler = {
             }
         })();
         return {
-            diff: `${args.name}: → priority ${targetPri} (${diffMeta})`,
+            diff: `${args.name}: → priority ${targetPri} [${space}] (${diffMeta})`,
             affectedFiles: [pluginsPath],
             targets: [{ path: pluginsPath, kind: "text-file" }],
         };
@@ -124,8 +181,8 @@ const handler = {
         const bound = requireBoundContext(ctx);
         const args = plan.args;
         const profile = args.profile ?? "Default";
-        const targetPri = await _computeTargetPriority(args, ctx, profile);
-        if (bound.pipeClient) {
+        const { priority: targetPri, useBroker } = await _computeTargetPriority(args, ctx, profile);
+        if (bound.pipeClient && useBroker) {
             await assertActiveProfile(ctx, profile);
             const resp = await bound.pipeClient.call("plugins.set_priority", {
                 name: args.name,
@@ -137,7 +194,7 @@ const handler = {
                 ...resp.result,
                 new_priority: targetPri,
                 target_mode: args.target_mode,
-                _meta: RESPONSE_META,
+                _meta: RESPONSE_META_BROKER,
             };
         }
         const pluginsPath = join(resolveProfileDir(ctx, profile), "plugins.txt");
@@ -148,14 +205,14 @@ const handler = {
             new_priority: targetPri,
             target_mode: args.target_mode,
             source: "offline_plugins_txt_reorder",
-            _meta: RESPONSE_META,
+            _meta: RESPONSE_META_OFFLINE,
         };
     },
 };
 registerTool({
     name: "mo2_send_plugin_to",
     tier: "T3",
-    description: "Reposition a plugin in plugins.txt by GUI-aligned target mode. Live: broker plugins.set_priority. Offline: plugins.txt rewrite. Vocabulary matches mo2_send_mod_to; see _meta in response for direction contract.",
+    description: "Reposition a plugin in plugins.txt by GUI-aligned target mode. Live: broker plugins.set_priority in mobase priority space. Offline: plugins.txt rewrite in forward-index space. Vocabulary matches mo2_send_mod_to; see _meta in response for direction and space contract.",
     inputSchema,
     handler: (args, ctx) => routeToPlanApply(handler, args, ctx, ctx.plans, ctx.snapshots),
 });

--- a/plugins/bgs-modding-superpowers/tools/mo2-mcp/src/tools/mo2-send-plugin-to.ts
+++ b/plugins/bgs-modding-superpowers/tools/mo2-mcp/src/tools/mo2-send-plugin-to.ts
@@ -1,12 +1,26 @@
 /**
  * mo2_send_plugin_to — T3 reposition a plugin by GUI-aligned target mode.
  *
- * plugins.txt is FORWARD order and matches the MO2 GUI plugins pane:
- *   - gui_top              → priority 0 (loaded first, loses all plugin conflicts)
- *   - gui_bottom           → priority N-1 (loaded last, wins all plugin conflicts)
+ * Two priority spaces:
+ *
+ * - LIVE (broker present): mobase `IPluginList::setPriority` operates in the
+ *   FULL plugin-priority space, which interleaves foreign-managed officials
+ *   (e.g., Starfield's 12 official masters at priorities 0..11) with the user-
+ *   controllable plugins. The broker is authoritative; this tool queries
+ *   `plugins.list` and computes targets against the real mobase priorities.
+ *   To keep the user-facing semantics intuitive, the target search is filtered
+ *   to plugins.txt entries (foreign officials are not addressable as anchors
+ *   and do not pin `gui_top`/`gui_bottom`).
+ *
+ * - OFFLINE (no broker): the tool rewrites plugins.txt directly. Priority is
+ *   the 0-based forward-index within plugins.txt (after the comment header).
+ *
+ * Vocabulary contract (mirrors MO2 GUI plugins panel — BOTTOM wins):
+ *   - gui_top              → priority of the FIRST plugins.txt entry (loaded first, loses all)
+ *   - gui_bottom           → priority of the LAST plugins.txt entry (loaded last, wins all)
  *   - wins_over <anchor>   → anchor.priority + 1
  *   - loses_to <anchor>    → anchor.priority - 1
- *   - raw_priority         → explicit plugins.txt priority, clamped [0, N-1]
+ *   - raw_priority         → explicit mobase priority (live) / plugins.txt index (offline), clamped
  */
 import { z } from "zod";
 import { readFile } from "node:fs/promises";
@@ -40,13 +54,53 @@ const inputSchema = z.discriminatedUnion("mode", [
   z.object({ mode: z.literal("apply"), plan_id: z.string().min(1), lease_token: z.string().min(1) }).strict(),
 ]);
 
-const RESPONSE_META = {
+const RESPONSE_META_BROKER = {
+  priority_convention: "mobase_full_space_higher_wins",
+  plugins_txt_file_order: "forward_matches_gui",
+  gui_direction_hint:
+    "priority is mobase IPluginList space; foreign officials occupy a leading prefix; higher_priority_wins",
+  priority_space: "mobase",
+};
+
+const RESPONSE_META_OFFLINE = {
   priority_convention: "plugins_txt_forward_space_higher_wins",
   plugins_txt_file_order: "forward_matches_gui",
   gui_direction_hint: "priority_0_at_gui_top_loads_first_loses; priority_(N-1)_at_gui_bottom_loads_last_wins",
+  priority_space: "plugins_txt_index",
 };
 
-async function _pluginPriorities(
+/**
+ * LIVE-mode priority view. Filters broker's full plugin list down to the
+ * plugins.txt entries (foreign officials excluded) so user-facing min/max
+ * and anchor lookups match what the curator sees in the GUI panel.
+ */
+async function _pluginPrioritiesFromBroker(
+  ctx: ToolContext,
+  profile: string,
+): Promise<Array<{ name: string; priority: number }>> {
+  const bound = requireBoundContext(ctx);
+  if (!bound.pipeClient) throw new Error("broker_required_for_live_priority_view");
+  const resp = await bound.pipeClient.call("plugins.list", {});
+  if (!resp.ok) throw new Error(resp.error?.message ?? "plugins.list failed");
+  const result = (resp.result as { plugins?: Array<{ name: string; priority?: unknown }> }) ?? {};
+  const list = result.plugins ?? [];
+
+  const profileData = await readProfile(join(bound.config.mo2Root, "profiles", profile));
+  const inPluginsTxt = new Set(
+    profileData.plugins.filter((p) => !p.isComment).map((p) => p.name),
+  );
+
+  return list
+    .filter((p) => inPluginsTxt.has(p.name))
+    .filter((p) => typeof p.priority === "number")
+    .map((p) => ({ name: p.name, priority: p.priority as number }));
+}
+
+/**
+ * OFFLINE-mode priority view. Assigns sequential 0-based indices over the
+ * plugins.txt entries (after the comment header).
+ */
+async function _pluginPrioritiesFromFile(
   ctx: ToolContext,
   profile: string,
 ): Promise<Array<{ name: string; priority: number }>> {
@@ -61,25 +115,37 @@ async function _computeTargetPriority(
   args: Record<string, unknown>,
   ctx: ToolContext,
   profile: string,
-): Promise<number> {
-  const plugins = await _pluginPriorities(ctx, profile);
-  const maxPri = Math.max(0, plugins.length - 1);
+): Promise<{ priority: number; useBroker: boolean }> {
+  const bound = requireBoundContext(ctx);
+  const useBroker = !!bound.pipeClient;
+  const plugins = useBroker
+    ? await _pluginPrioritiesFromBroker(ctx, profile)
+    : await _pluginPrioritiesFromFile(ctx, profile);
+
+  if (plugins.length === 0) {
+    throw new Error("no_plugins_in_profile");
+  }
+
+  const priorities = plugins.map((p) => p.priority);
+  const maxPri = Math.max(...priorities);
+  const minPri = Math.min(...priorities);
   const clamp = (v: number): number => Math.max(0, Math.min(v, maxPri));
-  const source = plugins.find((plugin) => plugin.name === args.name);
+
+  const source = plugins.find((p) => p.name === args.name);
   if (!source) throw new Error(`plugin_not_found: ${String(args.name)}`);
 
   const mode = args.target_mode as string;
   switch (mode) {
     case "gui_top":
-      return 0;
+      return { priority: minPri, useBroker };
     case "gui_bottom":
-      return maxPri;
+      return { priority: maxPri, useBroker };
     case "raw_priority": {
       const tp = args.target_priority;
       if (typeof tp !== "number" || !Number.isInteger(tp)) {
         throw new Error("raw_priority_requires_target_priority_int");
       }
-      return clamp(tp);
+      return { priority: clamp(tp), useBroker };
     }
     case "wins_over":
     case "loses_to": {
@@ -87,9 +153,12 @@ async function _computeTargetPriority(
       if (typeof anchorName !== "string" || anchorName.length === 0) {
         throw new Error(`${mode}_requires_anchor`);
       }
-      const anchor = plugins.find((plugin) => plugin.name === anchorName);
+      const anchor = plugins.find((p) => p.name === anchorName);
       if (!anchor) throw new Error(`anchor_not_found: ${anchorName}`);
-      return clamp(mode === "wins_over" ? anchor.priority + 1 : anchor.priority - 1);
+      return {
+        priority: clamp(mode === "wins_over" ? anchor.priority + 1 : anchor.priority - 1),
+        useBroker,
+      };
     }
     default:
       throw new Error(`unknown_mode: ${mode}`);
@@ -114,14 +183,13 @@ const handler: PlanApplyHandler = {
   async buildPlan(args, ctx) {
     const profile = (args.profile as string) ?? "Default";
     await assertActiveProfile(ctx, profile);
-    const targetPri = await _computeTargetPriority(args, ctx, profile);
+    const { priority: targetPri, useBroker } = await _computeTargetPriority(args, ctx, profile);
     const pluginsPath = join(resolveProfileDir(ctx, profile), "plugins.txt");
-    const p = await _pluginPriorities(ctx, profile);
-    const maxPri = Math.max(0, p.length - 1);
+    const space = useBroker ? "mobase" : "plugins_txt_index";
     const diffMeta = (() => {
       switch (args.target_mode) {
-        case "gui_top": return "gui_top (priority 0 = loads first = loses all)";
-        case "gui_bottom": return `gui_bottom (priority ${maxPri} = loads last = wins all)`;
+        case "gui_top": return `gui_top (priority ${targetPri} = loads first = loses all)`;
+        case "gui_bottom": return `gui_bottom (priority ${targetPri} = loads last = wins all)`;
         case "wins_over": return `wins_over ${args.anchor}`;
         case "loses_to": return `loses_to ${args.anchor}`;
         case "raw_priority": return `raw_priority ${args.target_priority}`;
@@ -129,7 +197,7 @@ const handler: PlanApplyHandler = {
       }
     })();
     return {
-      diff: `${args.name}: → priority ${targetPri} (${diffMeta})`,
+      diff: `${args.name}: → priority ${targetPri} [${space}] (${diffMeta})`,
       affectedFiles: [pluginsPath],
       targets: [{ path: pluginsPath, kind: "text-file" }],
     };
@@ -138,9 +206,9 @@ const handler: PlanApplyHandler = {
     const bound = requireBoundContext(ctx);
     const args = plan.args;
     const profile = (args.profile as string) ?? "Default";
-    const targetPri = await _computeTargetPriority(args, ctx, profile);
+    const { priority: targetPri, useBroker } = await _computeTargetPriority(args, ctx, profile);
 
-    if (bound.pipeClient) {
+    if (bound.pipeClient && useBroker) {
       await assertActiveProfile(ctx, profile);
       const resp = await bound.pipeClient.call("plugins.set_priority", {
         name: args.name,
@@ -151,7 +219,7 @@ const handler: PlanApplyHandler = {
         ...(resp.result as Record<string, unknown>),
         new_priority: targetPri,
         target_mode: args.target_mode,
-        _meta: RESPONSE_META,
+        _meta: RESPONSE_META_BROKER,
       };
     }
 
@@ -163,7 +231,7 @@ const handler: PlanApplyHandler = {
       new_priority: targetPri,
       target_mode: args.target_mode,
       source: "offline_plugins_txt_reorder",
-      _meta: RESPONSE_META,
+      _meta: RESPONSE_META_OFFLINE,
     };
   },
 };
@@ -172,7 +240,7 @@ registerTool({
   name: "mo2_send_plugin_to",
   tier: "T3",
   description:
-    "Reposition a plugin in plugins.txt by GUI-aligned target mode. Live: broker plugins.set_priority. Offline: plugins.txt rewrite. Vocabulary matches mo2_send_mod_to; see _meta in response for direction contract.",
+    "Reposition a plugin in plugins.txt by GUI-aligned target mode. Live: broker plugins.set_priority in mobase priority space. Offline: plugins.txt rewrite in forward-index space. Vocabulary matches mo2_send_mod_to; see _meta in response for direction and space contract.",
   inputSchema,
   handler: (args, ctx) =>
     routeToPlanApply(handler, args, ctx, ctx.plans, ctx.snapshots) as Promise<unknown>,

--- a/tools/mo2-mcp/src/tools/mo2-send-plugin-to.ts
+++ b/tools/mo2-mcp/src/tools/mo2-send-plugin-to.ts
@@ -1,12 +1,26 @@
 /**
  * mo2_send_plugin_to — T3 reposition a plugin by GUI-aligned target mode.
  *
- * plugins.txt is FORWARD order and matches the MO2 GUI plugins pane:
- *   - gui_top              → priority 0 (loaded first, loses all plugin conflicts)
- *   - gui_bottom           → priority N-1 (loaded last, wins all plugin conflicts)
+ * Two priority spaces:
+ *
+ * - LIVE (broker present): mobase `IPluginList::setPriority` operates in the
+ *   FULL plugin-priority space, which interleaves foreign-managed officials
+ *   (e.g., Starfield's 12 official masters at priorities 0..11) with the user-
+ *   controllable plugins. The broker is authoritative; this tool queries
+ *   `plugins.list` and computes targets against the real mobase priorities.
+ *   To keep the user-facing semantics intuitive, the target search is filtered
+ *   to plugins.txt entries (foreign officials are not addressable as anchors
+ *   and do not pin `gui_top`/`gui_bottom`).
+ *
+ * - OFFLINE (no broker): the tool rewrites plugins.txt directly. Priority is
+ *   the 0-based forward-index within plugins.txt (after the comment header).
+ *
+ * Vocabulary contract (mirrors MO2 GUI plugins panel — BOTTOM wins):
+ *   - gui_top              → priority of the FIRST plugins.txt entry (loaded first, loses all)
+ *   - gui_bottom           → priority of the LAST plugins.txt entry (loaded last, wins all)
  *   - wins_over <anchor>   → anchor.priority + 1
  *   - loses_to <anchor>    → anchor.priority - 1
- *   - raw_priority         → explicit plugins.txt priority, clamped [0, N-1]
+ *   - raw_priority         → explicit mobase priority (live) / plugins.txt index (offline), clamped
  */
 import { z } from "zod";
 import { readFile } from "node:fs/promises";
@@ -40,13 +54,53 @@ const inputSchema = z.discriminatedUnion("mode", [
   z.object({ mode: z.literal("apply"), plan_id: z.string().min(1), lease_token: z.string().min(1) }).strict(),
 ]);
 
-const RESPONSE_META = {
+const RESPONSE_META_BROKER = {
+  priority_convention: "mobase_full_space_higher_wins",
+  plugins_txt_file_order: "forward_matches_gui",
+  gui_direction_hint:
+    "priority is mobase IPluginList space; foreign officials occupy a leading prefix; higher_priority_wins",
+  priority_space: "mobase",
+};
+
+const RESPONSE_META_OFFLINE = {
   priority_convention: "plugins_txt_forward_space_higher_wins",
   plugins_txt_file_order: "forward_matches_gui",
   gui_direction_hint: "priority_0_at_gui_top_loads_first_loses; priority_(N-1)_at_gui_bottom_loads_last_wins",
+  priority_space: "plugins_txt_index",
 };
 
-async function _pluginPriorities(
+/**
+ * LIVE-mode priority view. Filters broker's full plugin list down to the
+ * plugins.txt entries (foreign officials excluded) so user-facing min/max
+ * and anchor lookups match what the curator sees in the GUI panel.
+ */
+async function _pluginPrioritiesFromBroker(
+  ctx: ToolContext,
+  profile: string,
+): Promise<Array<{ name: string; priority: number }>> {
+  const bound = requireBoundContext(ctx);
+  if (!bound.pipeClient) throw new Error("broker_required_for_live_priority_view");
+  const resp = await bound.pipeClient.call("plugins.list", {});
+  if (!resp.ok) throw new Error(resp.error?.message ?? "plugins.list failed");
+  const result = (resp.result as { plugins?: Array<{ name: string; priority?: unknown }> }) ?? {};
+  const list = result.plugins ?? [];
+
+  const profileData = await readProfile(join(bound.config.mo2Root, "profiles", profile));
+  const inPluginsTxt = new Set(
+    profileData.plugins.filter((p) => !p.isComment).map((p) => p.name),
+  );
+
+  return list
+    .filter((p) => inPluginsTxt.has(p.name))
+    .filter((p) => typeof p.priority === "number")
+    .map((p) => ({ name: p.name, priority: p.priority as number }));
+}
+
+/**
+ * OFFLINE-mode priority view. Assigns sequential 0-based indices over the
+ * plugins.txt entries (after the comment header).
+ */
+async function _pluginPrioritiesFromFile(
   ctx: ToolContext,
   profile: string,
 ): Promise<Array<{ name: string; priority: number }>> {
@@ -61,25 +115,37 @@ async function _computeTargetPriority(
   args: Record<string, unknown>,
   ctx: ToolContext,
   profile: string,
-): Promise<number> {
-  const plugins = await _pluginPriorities(ctx, profile);
-  const maxPri = Math.max(0, plugins.length - 1);
+): Promise<{ priority: number; useBroker: boolean }> {
+  const bound = requireBoundContext(ctx);
+  const useBroker = !!bound.pipeClient;
+  const plugins = useBroker
+    ? await _pluginPrioritiesFromBroker(ctx, profile)
+    : await _pluginPrioritiesFromFile(ctx, profile);
+
+  if (plugins.length === 0) {
+    throw new Error("no_plugins_in_profile");
+  }
+
+  const priorities = plugins.map((p) => p.priority);
+  const maxPri = Math.max(...priorities);
+  const minPri = Math.min(...priorities);
   const clamp = (v: number): number => Math.max(0, Math.min(v, maxPri));
-  const source = plugins.find((plugin) => plugin.name === args.name);
+
+  const source = plugins.find((p) => p.name === args.name);
   if (!source) throw new Error(`plugin_not_found: ${String(args.name)}`);
 
   const mode = args.target_mode as string;
   switch (mode) {
     case "gui_top":
-      return 0;
+      return { priority: minPri, useBroker };
     case "gui_bottom":
-      return maxPri;
+      return { priority: maxPri, useBroker };
     case "raw_priority": {
       const tp = args.target_priority;
       if (typeof tp !== "number" || !Number.isInteger(tp)) {
         throw new Error("raw_priority_requires_target_priority_int");
       }
-      return clamp(tp);
+      return { priority: clamp(tp), useBroker };
     }
     case "wins_over":
     case "loses_to": {
@@ -87,9 +153,12 @@ async function _computeTargetPriority(
       if (typeof anchorName !== "string" || anchorName.length === 0) {
         throw new Error(`${mode}_requires_anchor`);
       }
-      const anchor = plugins.find((plugin) => plugin.name === anchorName);
+      const anchor = plugins.find((p) => p.name === anchorName);
       if (!anchor) throw new Error(`anchor_not_found: ${anchorName}`);
-      return clamp(mode === "wins_over" ? anchor.priority + 1 : anchor.priority - 1);
+      return {
+        priority: clamp(mode === "wins_over" ? anchor.priority + 1 : anchor.priority - 1),
+        useBroker,
+      };
     }
     default:
       throw new Error(`unknown_mode: ${mode}`);
@@ -114,14 +183,13 @@ const handler: PlanApplyHandler = {
   async buildPlan(args, ctx) {
     const profile = (args.profile as string) ?? "Default";
     await assertActiveProfile(ctx, profile);
-    const targetPri = await _computeTargetPriority(args, ctx, profile);
+    const { priority: targetPri, useBroker } = await _computeTargetPriority(args, ctx, profile);
     const pluginsPath = join(resolveProfileDir(ctx, profile), "plugins.txt");
-    const p = await _pluginPriorities(ctx, profile);
-    const maxPri = Math.max(0, p.length - 1);
+    const space = useBroker ? "mobase" : "plugins_txt_index";
     const diffMeta = (() => {
       switch (args.target_mode) {
-        case "gui_top": return "gui_top (priority 0 = loads first = loses all)";
-        case "gui_bottom": return `gui_bottom (priority ${maxPri} = loads last = wins all)`;
+        case "gui_top": return `gui_top (priority ${targetPri} = loads first = loses all)`;
+        case "gui_bottom": return `gui_bottom (priority ${targetPri} = loads last = wins all)`;
         case "wins_over": return `wins_over ${args.anchor}`;
         case "loses_to": return `loses_to ${args.anchor}`;
         case "raw_priority": return `raw_priority ${args.target_priority}`;
@@ -129,7 +197,7 @@ const handler: PlanApplyHandler = {
       }
     })();
     return {
-      diff: `${args.name}: → priority ${targetPri} (${diffMeta})`,
+      diff: `${args.name}: → priority ${targetPri} [${space}] (${diffMeta})`,
       affectedFiles: [pluginsPath],
       targets: [{ path: pluginsPath, kind: "text-file" }],
     };
@@ -138,9 +206,9 @@ const handler: PlanApplyHandler = {
     const bound = requireBoundContext(ctx);
     const args = plan.args;
     const profile = (args.profile as string) ?? "Default";
-    const targetPri = await _computeTargetPriority(args, ctx, profile);
+    const { priority: targetPri, useBroker } = await _computeTargetPriority(args, ctx, profile);
 
-    if (bound.pipeClient) {
+    if (bound.pipeClient && useBroker) {
       await assertActiveProfile(ctx, profile);
       const resp = await bound.pipeClient.call("plugins.set_priority", {
         name: args.name,
@@ -151,7 +219,7 @@ const handler: PlanApplyHandler = {
         ...(resp.result as Record<string, unknown>),
         new_priority: targetPri,
         target_mode: args.target_mode,
-        _meta: RESPONSE_META,
+        _meta: RESPONSE_META_BROKER,
       };
     }
 
@@ -163,7 +231,7 @@ const handler: PlanApplyHandler = {
       new_priority: targetPri,
       target_mode: args.target_mode,
       source: "offline_plugins_txt_reorder",
-      _meta: RESPONSE_META,
+      _meta: RESPONSE_META_OFFLINE,
     };
   },
 };
@@ -172,7 +240,7 @@ registerTool({
   name: "mo2_send_plugin_to",
   tier: "T3",
   description:
-    "Reposition a plugin in plugins.txt by GUI-aligned target mode. Live: broker plugins.set_priority. Offline: plugins.txt rewrite. Vocabulary matches mo2_send_mod_to; see _meta in response for direction contract.",
+    "Reposition a plugin in plugins.txt by GUI-aligned target mode. Live: broker plugins.set_priority in mobase priority space. Offline: plugins.txt rewrite in forward-index space. Vocabulary matches mo2_send_mod_to; see _meta in response for direction and space contract.",
   inputSchema,
   handler: (args, ctx) =>
     routeToPlanApply(handler, args, ctx, ctx.plans, ctx.snapshots) as Promise<unknown>,

--- a/tools/mo2-mcp/tests/tools/mo2-send-plugin-to.test.ts
+++ b/tools/mo2-mcp/tests/tools/mo2-send-plugin-to.test.ts
@@ -41,12 +41,36 @@ async function _fixture(
   return { root, ctx };
 }
 
-function _pipeClient(calls: Array<{ method: string; params: unknown }>): ToolContext["pipeClient"] {
+/**
+ * Mock pipeClient. brokerPlugins simulates the broker's `plugins.list`
+ * response — a flat list of name/priority pairs in mobase priority space.
+ * For Starfield-style fixtures, this includes a foreign-officials prefix
+ * (e.g., priorities 0..11) so we can prove the live path uses mobase
+ * priorities, NOT plugins.txt forward-index space.
+ */
+function _pipeClient(
+  calls: Array<{ method: string; params: unknown }>,
+  brokerPlugins: Array<{ name: string; priority: number }> = [
+    { name: "Base.esm", priority: 0 },
+    { name: "Anchor.esm", priority: 1 },
+    { name: "Source.esp", priority: 2 },
+    { name: "Last.esp", priority: 3 },
+  ],
+): ToolContext["pipeClient"] {
   return {
     call: async (method: string, params: unknown) => {
       calls.push({ method, params });
       if (method === "profile.active") return { ok: true, result: { name: "Default" }, error: null };
-      if (method === "plugins.set_priority") return { ok: true, result: { actual_priority: (params as { priority: number }).priority }, error: null };
+      if (method === "plugins.list") {
+        return {
+          ok: true,
+          result: { plugins: brokerPlugins.map((p) => ({ name: p.name, priority: p.priority })) },
+          error: null,
+        };
+      }
+      if (method === "plugins.set_priority") {
+        return { ok: true, result: { actual_priority: (params as { priority: number }).priority }, error: null };
+      }
       throw new Error(`unexpected broker method ${method}`);
     },
     close: () => {},
@@ -73,122 +97,253 @@ describe("mo2_send_plugin_to", () => {
     expect(getTool("mo2_send_plugin_to")?.tier).toBe("T3");
   });
 
-  it("gui_top maps to priority 0 in FORWARD plugins.txt space (loads first = loses)", async () => {
-    const { ctx } = await _fixture();
-    const plan = await _plan({ target_mode: "gui_top" }, ctx);
+  describe("OFFLINE path (no broker, plugins.txt index space)", () => {
+    it("gui_top maps to priority 0 in FORWARD plugins.txt space (loads first = loses)", async () => {
+      const { ctx } = await _fixture();
+      const plan = await _plan({ target_mode: "gui_top" }, ctx);
 
-    expect(plan.ok).toBe(true);
-    expect(plan.result.diff).toContain("priority 0");
-    expect(plan.result.diff).toContain("gui_top (priority 0 = loads first = loses all)");
-  });
+      expect(plan.ok).toBe(true);
+      expect(plan.result.diff).toContain("priority 0");
+      expect(plan.result.diff).toContain("[plugins_txt_index]");
+      expect(plan.result.diff).toContain("gui_top (priority 0 = loads first = loses all)");
+    });
 
-  it("gui_bottom maps to priority N-1 (loads last = wins)", async () => {
-    const { ctx } = await _fixture();
-    const plan = await _plan({ target_mode: "gui_bottom" }, ctx);
+    it("gui_bottom maps to priority N-1 (loads last = wins)", async () => {
+      const { ctx } = await _fixture();
+      const plan = await _plan({ target_mode: "gui_bottom" }, ctx);
 
-    expect(plan.ok).toBe(true);
-    expect(plan.result.diff).toContain("priority 3");
-    expect(plan.result.diff).toContain("gui_bottom (priority 3 = loads last = wins all)");
-  });
+      expect(plan.ok).toBe(true);
+      expect(plan.result.diff).toContain("priority 3");
+      expect(plan.result.diff).toContain("[plugins_txt_index]");
+      expect(plan.result.diff).toContain("gui_bottom (priority 3 = loads last = wins all)");
+    });
 
-  it("wins_over targets anchor.priority + 1", async () => {
-    const { ctx } = await _fixture();
-    const plan = await _plan({ target_mode: "wins_over", anchor: "Anchor.esm" }, ctx);
+    it("wins_over targets anchor.priority + 1", async () => {
+      const { ctx } = await _fixture();
+      const plan = await _plan({ target_mode: "wins_over", anchor: "Anchor.esm" }, ctx);
 
-    expect(plan.ok).toBe(true);
-    expect(plan.result.diff).toContain("priority 2");
-    expect(plan.result.diff).toContain("wins_over Anchor.esm");
-  });
+      expect(plan.ok).toBe(true);
+      expect(plan.result.diff).toContain("priority 2");
+      expect(plan.result.diff).toContain("wins_over Anchor.esm");
+    });
 
-  it("loses_to targets anchor.priority - 1", async () => {
-    const { ctx } = await _fixture();
-    const plan = await _plan({ target_mode: "loses_to", anchor: "Anchor.esm" }, ctx);
+    it("loses_to targets anchor.priority - 1", async () => {
+      const { ctx } = await _fixture();
+      const plan = await _plan({ target_mode: "loses_to", anchor: "Anchor.esm" }, ctx);
 
-    expect(plan.ok).toBe(true);
-    expect(plan.result.diff).toContain("priority 0");
-    expect(plan.result.diff).toContain("loses_to Anchor.esm");
-  });
+      expect(plan.ok).toBe(true);
+      expect(plan.result.diff).toContain("priority 0");
+      expect(plan.result.diff).toContain("loses_to Anchor.esm");
+    });
 
-  it("raw_priority uses explicit priority and clamps to profile bounds", async () => {
-    const { ctx } = await _fixture();
-    const plan = await _plan({ target_mode: "raw_priority", target_priority: 99 }, ctx);
+    it("raw_priority uses explicit priority and clamps to profile bounds", async () => {
+      const { ctx } = await _fixture();
+      const plan = await _plan({ target_mode: "raw_priority", target_priority: 99 }, ctx);
 
-    expect(plan.ok).toBe(true);
-    expect(plan.result.diff).toContain("priority 3");
-    expect(plan.result.diff).toContain("raw_priority 99");
-  });
+      expect(plan.ok).toBe(true);
+      expect(plan.result.diff).toContain("priority 3");
+      expect(plan.result.diff).toContain("raw_priority 99");
+    });
 
-  it("apply live path invokes broker plugins.set_priority with FORWARD-space priority", async () => {
-    const { ctx } = await _fixture();
-    const calls: Array<{ method: string; params: unknown }> = [];
-    ctx.pipeClient = _pipeClient(calls);
-    const tool = getTool("mo2_send_plugin_to")!;
-    const plan = await _plan({ target_mode: "wins_over", anchor: "Anchor.esm" }, ctx);
+    it("offline apply rewrites plugins.txt in GUI/forward order", async () => {
+      const { root, ctx } = await _fixture();
+      const tool = getTool("mo2_send_plugin_to")!;
+      const plan = await _plan({ target_mode: "gui_top" }, ctx);
 
-    const apply = await tool.handler({ mode: "apply", plan_id: plan.result.plan_id, lease_token: plan.result.lease_token }, ctx) as {
-      ok: boolean;
-      result: { target_mode: string; _meta: Record<string, string> };
-    };
+      const apply = await tool.handler({ mode: "apply", plan_id: plan.result.plan_id, lease_token: plan.result.lease_token }, ctx) as {
+        ok: boolean;
+        result: { source: string; new_priority: number; _meta: Record<string, string> };
+      };
 
-    expect(apply.ok).toBe(true);
-    expect(calls.find((c) => c.method === "plugins.set_priority")?.params).toMatchObject({ name: "Source.esp", priority: 2 });
-    expect(apply.result.target_mode).toBe("wins_over");
-    expect(apply.result._meta).toEqual({
-      priority_convention: "plugins_txt_forward_space_higher_wins",
-      plugins_txt_file_order: "forward_matches_gui",
-      gui_direction_hint: "priority_0_at_gui_top_loads_first_loses; priority_(N-1)_at_gui_bottom_loads_last_wins",
+      expect(apply.ok).toBe(true);
+      expect(apply.result.source).toBe("offline_plugins_txt_reorder");
+      expect(apply.result.new_priority).toBe(0);
+      expect(apply.result._meta.plugins_txt_file_order).toBe("forward_matches_gui");
+      expect(apply.result._meta.priority_space).toBe("plugins_txt_index");
+      const pluginsTxt = await readFile(join(root, "profiles", "Default", "plugins.txt"), "utf8");
+      expect(pluginsTxt.trim().split(/\r?\n/)).toEqual(["*Source.esp", "*Base.esm", "*Anchor.esm", "*Last.esp"]);
     });
   });
 
-  it("offline apply rewrites plugins.txt in GUI/forward order", async () => {
-    const { root, ctx } = await _fixture();
-    const tool = getTool("mo2_send_plugin_to")!;
-    const plan = await _plan({ target_mode: "gui_top" }, ctx);
+  describe("LIVE path (broker, mobase priority space)", () => {
+    it("wins_over uses anchor's mobase priority (not plugins.txt index) — issue #20 Bug 1 regression", async () => {
+      // Starfield-style fixture: 12 foreign officials at priorities 0..11,
+      // then the user plugins at 12..15. anchor.mobase_priority = 13.
+      const brokerPlugins = [
+        ...Array.from({ length: 12 }, (_, i) => ({ name: `Official${i}.esm`, priority: i })),
+        { name: "Base.esm", priority: 12 },
+        { name: "Anchor.esm", priority: 13 },
+        { name: "Source.esp", priority: 14 },
+        { name: "Last.esp", priority: 15 },
+      ];
+      const { ctx } = await _fixture();
+      const calls: Array<{ method: string; params: unknown }> = [];
+      ctx.pipeClient = _pipeClient(calls, brokerPlugins);
+      const tool = getTool("mo2_send_plugin_to")!;
+      const plan = await _plan({ target_mode: "wins_over", anchor: "Anchor.esm" }, ctx);
 
-    const apply = await tool.handler({ mode: "apply", plan_id: plan.result.plan_id, lease_token: plan.result.lease_token }, ctx) as {
-      ok: boolean;
-      result: { source: string; new_priority: number; _meta: Record<string, string> };
-    };
+      // The OLD buggy code would have returned priority 2 (TS index of Anchor.esm + 1).
+      // The fixed code returns 14 (Anchor.esm's mobase priority + 1).
+      expect(plan.result.diff).toContain("priority 14");
+      expect(plan.result.diff).toContain("[mobase]");
 
-    expect(apply.ok).toBe(true);
-    expect(apply.result.source).toBe("offline_plugins_txt_reorder");
-    expect(apply.result.new_priority).toBe(0);
-    expect(apply.result._meta.plugins_txt_file_order).toBe("forward_matches_gui");
-    const pluginsTxt = await readFile(join(root, "profiles", "Default", "plugins.txt"), "utf8");
-    expect(pluginsTxt.trim().split(/\r?\n/)).toEqual(["*Source.esp", "*Base.esm", "*Anchor.esm", "*Last.esp"]);
+      const apply = await tool.handler({ mode: "apply", plan_id: plan.result.plan_id, lease_token: plan.result.lease_token }, ctx) as {
+        ok: boolean;
+        result: { target_mode: string; new_priority: number; _meta: Record<string, string> };
+      };
+
+      expect(apply.ok).toBe(true);
+      expect(calls.find((c) => c.method === "plugins.set_priority")?.params).toMatchObject({
+        name: "Source.esp",
+        priority: 14,
+      });
+      expect(apply.result.new_priority).toBe(14);
+      expect(apply.result.target_mode).toBe("wins_over");
+      expect(apply.result._meta.priority_space).toBe("mobase");
+    });
+
+    it("gui_bottom targets MAX mobase priority across plugins.txt entries — issue #20 Bug 2 regression", async () => {
+      // BB84-like Starfield fixture: 12 officials + 4 user plugins, max user
+      // priority = 15. The OLD buggy code would have returned priority 3
+      // (TS plugins.length - 1). The fixed code returns 15.
+      const brokerPlugins = [
+        ...Array.from({ length: 12 }, (_, i) => ({ name: `Official${i}.esm`, priority: i })),
+        { name: "Base.esm", priority: 12 },
+        { name: "Anchor.esm", priority: 13 },
+        { name: "Source.esp", priority: 14 },
+        { name: "Last.esp", priority: 15 },
+      ];
+      const { ctx } = await _fixture();
+      const calls: Array<{ method: string; params: unknown }> = [];
+      ctx.pipeClient = _pipeClient(calls, brokerPlugins);
+      const tool = getTool("mo2_send_plugin_to")!;
+      const plan = await _plan({ target_mode: "gui_bottom" }, ctx);
+
+      expect(plan.result.diff).toContain("priority 15");
+      expect(plan.result.diff).toContain("[mobase]");
+
+      const apply = await tool.handler({ mode: "apply", plan_id: plan.result.plan_id, lease_token: plan.result.lease_token }, ctx) as {
+        ok: boolean;
+        result: { new_priority: number };
+      };
+
+      expect(calls.find((c) => c.method === "plugins.set_priority")?.params).toMatchObject({
+        name: "Source.esp",
+        priority: 15,
+      });
+      expect(apply.result.new_priority).toBe(15);
+    });
+
+    it("gui_top targets MIN priority among plugins.txt entries (skips foreign officials)", async () => {
+      const brokerPlugins = [
+        ...Array.from({ length: 12 }, (_, i) => ({ name: `Official${i}.esm`, priority: i })),
+        { name: "Base.esm", priority: 12 },
+        { name: "Anchor.esm", priority: 13 },
+        { name: "Source.esp", priority: 14 },
+        { name: "Last.esp", priority: 15 },
+      ];
+      const { ctx } = await _fixture();
+      const calls: Array<{ method: string; params: unknown }> = [];
+      ctx.pipeClient = _pipeClient(calls, brokerPlugins);
+      const tool = getTool("mo2_send_plugin_to")!;
+      const plan = await _plan({ target_mode: "gui_top" }, ctx);
+
+      // gui_top = min(plugins.txt entries) = 12 (skips officials at 0..11)
+      expect(plan.result.diff).toContain("priority 12");
+      expect(plan.result.diff).toContain("[mobase]");
+    });
+
+    it("loses_to targets anchor.mobase_priority - 1", async () => {
+      const brokerPlugins = [
+        { name: "Base.esm", priority: 12 },
+        { name: "Anchor.esm", priority: 13 },
+        { name: "Source.esp", priority: 14 },
+        { name: "Last.esp", priority: 15 },
+      ];
+      const { ctx } = await _fixture();
+      const calls: Array<{ method: string; params: unknown }> = [];
+      ctx.pipeClient = _pipeClient(calls, brokerPlugins);
+      const plan = await _plan({ target_mode: "loses_to", anchor: "Anchor.esm" }, ctx);
+
+      expect(plan.result.diff).toContain("priority 12");
+      expect(plan.result.diff).toContain("loses_to Anchor.esm");
+    });
+
+    it("raw_priority clamps to mobase max priority of plugins.txt entries", async () => {
+      const brokerPlugins = [
+        { name: "Base.esm", priority: 12 },
+        { name: "Anchor.esm", priority: 13 },
+        { name: "Source.esp", priority: 14 },
+        { name: "Last.esp", priority: 15 },
+      ];
+      const { ctx } = await _fixture();
+      const calls: Array<{ method: string; params: unknown }> = [];
+      ctx.pipeClient = _pipeClient(calls, brokerPlugins);
+      const plan = await _plan({ target_mode: "raw_priority", target_priority: 9999 }, ctx);
+
+      expect(plan.result.diff).toContain("priority 15");
+    });
+
+    it("apply response carries mobase priority_space marker", async () => {
+      const brokerPlugins = [
+        { name: "Base.esm", priority: 12 },
+        { name: "Anchor.esm", priority: 13 },
+        { name: "Source.esp", priority: 14 },
+        { name: "Last.esp", priority: 15 },
+      ];
+      const { ctx } = await _fixture();
+      const calls: Array<{ method: string; params: unknown }> = [];
+      ctx.pipeClient = _pipeClient(calls, brokerPlugins);
+      const tool = getTool("mo2_send_plugin_to")!;
+      const plan = await _plan({ target_mode: "wins_over", anchor: "Anchor.esm" }, ctx);
+      const apply = await tool.handler({ mode: "apply", plan_id: plan.result.plan_id, lease_token: plan.result.lease_token }, ctx) as {
+        ok: boolean;
+        result: { _meta: Record<string, string> };
+      };
+
+      expect(apply.result._meta).toEqual({
+        priority_convention: "mobase_full_space_higher_wins",
+        plugins_txt_file_order: "forward_matches_gui",
+        gui_direction_hint:
+          "priority is mobase IPluginList space; foreign officials occupy a leading prefix; higher_priority_wins",
+        priority_space: "mobase",
+      });
+    });
   });
 
-  it("throws when wins_over is missing anchor", async () => {
-    const { ctx } = await _fixture();
+  describe("error paths", () => {
+    it("throws when wins_over is missing anchor", async () => {
+      const { ctx } = await _fixture();
 
-    await expect(_plan({ target_mode: "wins_over" }, ctx)).rejects.toThrow(/wins_over_requires_anchor/);
-  });
+      await expect(_plan({ target_mode: "wins_over" }, ctx)).rejects.toThrow(/wins_over_requires_anchor/);
+    });
 
-  it("throws when anchor is unknown", async () => {
-    const { ctx } = await _fixture();
+    it("throws when anchor is unknown", async () => {
+      const { ctx } = await _fixture();
 
-    await expect(_plan({ target_mode: "wins_over", anchor: "Missing.esm" }, ctx)).rejects.toThrow(/anchor_not_found: Missing.esm/);
-  });
+      await expect(_plan({ target_mode: "wins_over", anchor: "Missing.esm" }, ctx)).rejects.toThrow(/anchor_not_found: Missing.esm/);
+    });
 
-  it("throws when raw_priority is missing target_priority", async () => {
-    const { ctx } = await _fixture();
+    it("throws when raw_priority is missing target_priority", async () => {
+      const { ctx } = await _fixture();
 
-    await expect(_plan({ target_mode: "raw_priority" }, ctx)).rejects.toThrow(/raw_priority_requires_target_priority_int/);
-  });
+      await expect(_plan({ target_mode: "raw_priority" }, ctx)).rejects.toThrow(/raw_priority_requires_target_priority_int/);
+    });
 
-  it("throws when source plugin is missing", async () => {
-    const { ctx } = await _fixture(["*Base.esm", "*Anchor.esm"]);
+    it("throws when source plugin is missing", async () => {
+      const { ctx } = await _fixture(["*Base.esm", "*Anchor.esm"]);
 
-    await expect(_plan({ target_mode: "gui_bottom" }, ctx)).rejects.toThrow(/plugin_not_found: Source.esp/);
-  });
+      await expect(_plan({ target_mode: "gui_bottom" }, ctx)).rejects.toThrow(/plugin_not_found: Source.esp/);
+    });
 
-  it("cross-profile live plan blocks when requested profile is not the active MO2 profile", async () => {
-    const { ctx } = await _fixture();
-    const calls: Array<{ method: string; params: unknown }> = [];
-    ctx.pipeClient = _pipeClient(calls);
+    it("cross-profile live plan blocks when requested profile is not the active MO2 profile", async () => {
+      const { ctx } = await _fixture();
+      const calls: Array<{ method: string; params: unknown }> = [];
+      ctx.pipeClient = _pipeClient(calls);
 
-    await expect(
-      _plan({ target_mode: "gui_top", profile: "BB84自用" }, ctx),
-    ).rejects.toThrow(/cross_profile_live_mutation_blocked/);
+      await expect(
+        _plan({ target_mode: "gui_top", profile: "BB84自用" }, ctx),
+      ).rejects.toThrow(/cross_profile_live_mutation_blocked/);
+    });
   });
 });


### PR DESCRIPTION
## Summary
Fixes #20. Mo2Mo2SendPluginTo_tool priority computation was in plugins.txt-forward-index space (0..N-1) but broker `plugins.set_priority` operates in mobase IPluginList space — which includes 12 foreign-master priorities at 0..11 for Starfield plus disabled-plugin offsets. The two index spaces only coincide for games with zero foreign masters and zero disabled plugins; on a real Starfield modpack the gap is 11-13 slots, producing the inverted `wins_over` and under-shot `gui_bottom` reported in the issue.

## Fix
- Add `_pluginPrioritiesFromBroker(ctx, profile)` that queries broker `plugins.list` and filters to plugins.txt entries (foreign officials excluded so user-facing min/max match the GUI plugins panel).
- `_computeTargetPriority` now returns `{priority, useBroker}`; live mode uses broker priorities (mobase space), offline path keeps plugins.txt forward index (correct for offline file rewrite).
- `gui_top` → `min(plugins.txt entries' mobase priorities)` — skips foreign at 0..11.
- `gui_bottom` → `max(...)`.
- `wins_over`/`loses_to` → `anchor.mobase_priority ± 1`.
- `raw_priority` → clamp to `[0, max(...)]`.
- Diff string and `_meta.priority_space` now tag every response with `mobase` or `plugins_txt_index`.

## Unit tests
577 passed, including 2 dedicated regression cases (Bug 1 + Bug 2) that mock a Starfield-style 12-officials prefix.

## Live verification (D:\Starfield MO2 BB84自用2, 174 enabled plugins + 12 foreign masters)
- **Case 1 (Bug 1 — wins_over)**: `wins_over rvspace.esm` planned `priority 173 [mobase]` (anchor.priority 172 + 1), applied, plugins.txt readback: rvspace-patch.esm at line 163, rvspace.esm at line 161. Patch is now AFTER anchor = WINS. OLD bug would have shipped priority 162 → patch BEFORE anchor (the inversion in the issue).
- **Case 2 (Bug 2 — gui_bottom)**: `gui_bottom Take Your Time.esm` planned `priority 185 [mobase]`. TYT landed at plugins.txt line 175 of 175 — gap to bottom = 0. OLD bug shipped 173, leaving 12 plugins after.
- State rolled back to pre-test layout via snapshot system after each case. Final state matches issue-rollback baseline.

## Cross-references
- Issue: https://github.com/BB-84C/bgs-modding-superpowers/issues/20
- Sibling fix: PRs #17/#18 (mo2_send_mod_to / modlist.txt). Plugin-side semantic was implicitly added in PR #18 but not live-verified with the same rigor; this PR closes that gap.
- Broker handler unchanged; broker's `plugin_list.setPriority` already operates correctly in mobase space (this was always the source of truth).
